### PR TITLE
 Extend PUT request to handle authentication header

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ dp-filter-api
 | FILTER_JOB_SUBMITTED_TOPIC | filter-job-submitted-topic                | The kafka topic to write messages to
 | KAFKA_MAX_BYTES            | 2000000                | The maximum permitted size of a message. Should be set equal to or smaller than the broker's `message.max.bytes`
 | POSTGRES_URL               | user=dp dbname=FilterJobs sslmode=disable | URL to a Postgres services
+| SECRET_KEY                 | FD0108EA-825D-411C-9B1D-41EF7727F465      | A secret key used authentication
 
 ### Contributing
 

--- a/api/api.go
+++ b/api/api.go
@@ -12,17 +12,18 @@ type JobQueue interface {
 
 // FilterAPI manages importing filters against a dataset
 type FilterAPI struct {
-	host      string
-	dataStore DataStore
-	router    *mux.Router
-	jobQueue  JobQueue
+	host          string
+	dataStore     DataStore
+	internalToken string
+	jobQueue      JobQueue
+	router        *mux.Router
 }
 
 // CreateFilterAPI manages all the routes configured to API
-func CreateFilterAPI(host string, router *mux.Router, dataStore DataStore, jobQueue JobQueue) *FilterAPI {
+func CreateFilterAPI(secretKey string, host string, router *mux.Router, dataStore DataStore, jobQueue JobQueue) *FilterAPI {
 	router.Path("/healthcheck").Methods("GET").HandlerFunc(healthCheck)
 
-	api := FilterAPI{host: host, dataStore: dataStore, router: router, jobQueue: jobQueue}
+	api := FilterAPI{internalToken: secretKey, host: host, dataStore: dataStore, router: router, jobQueue: jobQueue}
 	api.router.HandleFunc("/filters", api.addFilterJob).Methods("POST")
 	api.router.HandleFunc("/filters/{filter_job_id}", api.getFilterJob).Methods("GET")
 	api.router.HandleFunc("/filters/{filter_job_id}", api.updateFilterJob).Methods("PUT")

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -13,7 +13,10 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-var host = "http://localhost:80"
+var (
+	host       = "http://localhost:80"
+	authHeader = "cake"
+)
 
 func TestSuccessfulAddFilterJob(t *testing.T) {
 	t.Parallel()
@@ -23,7 +26,7 @@ func TestSuccessfulAddFilterJob(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -37,13 +40,13 @@ func TestAddFilterFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Internal server error\n")
+		So(response, ShouldResemble, "Failed to process the request due to an internal error\n")
 	})
 
 	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
@@ -52,7 +55,7 @@ func TestAddFilterFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -67,7 +70,7 @@ func TestAddFilterFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -82,7 +85,7 @@ func TestAddFilterFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -100,7 +103,7 @@ func TestSuccessfulAddFilterJobDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -111,7 +114,7 @@ func TestSuccessfulAddFilterJobDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -122,7 +125,7 @@ func TestSuccessfulAddFilterJobDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -136,13 +139,13 @@ func TestAddFilterJobDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Internal server error\n")
+		So(response, ShouldResemble, "Failed to process the request due to an internal error\n")
 	})
 
 	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
@@ -151,7 +154,7 @@ func TestAddFilterJobDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -166,7 +169,7 @@ func TestAddFilterJobDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -181,13 +184,13 @@ func TestAddFilterJobDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{Forbidden: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{Forbidden: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter job request forbidden\n")
+		So(response, ShouldResemble, "Forbidden, the job has been locked as it has been submitted to be processed\n")
 	})
 }
 
@@ -198,7 +201,7 @@ func TestSuccessfulAddFilterJobDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -211,13 +214,13 @@ func TestAddFilterJobDimensionOptionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Internal server error\n")
+		So(response, ShouldResemble, "Failed to process the request due to an internal error\n")
 	})
 
 	Convey("When the filter job does not exist, a bad request status is returned", t, func() {
@@ -225,7 +228,7 @@ func TestAddFilterJobDimensionOptionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -239,13 +242,13 @@ func TestAddFilterJobDimensionOptionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{Forbidden: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{Forbidden: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter job request forbidden\n")
+		So(response, ShouldResemble, "Forbidden, the job has been locked as it has been submitted to be processed\n")
 	})
 
 	Convey("When a dimension for filter job does not exist, a not found status is returned", t, func() {
@@ -253,7 +256,7 @@ func TestAddFilterJobDimensionOptionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -269,7 +272,7 @@ func TestSuccessfulGetFilterJob(t *testing.T) {
 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
 		So(err, ShouldBeNil)
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -283,7 +286,7 @@ func TestGetFilterFailure(t *testing.T) {
 
 		w := httptest.NewRecorder()
 
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 	})
@@ -293,7 +296,7 @@ func TestGetFilterFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -311,7 +314,7 @@ func TestSuccessfulUpdateFilterJob(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -325,7 +328,7 @@ func TestFailedUpdateFilterJob(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -340,7 +343,7 @@ func TestFailedUpdateFilterJob(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -355,7 +358,7 @@ func TestFailedUpdateFilterJob(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -370,7 +373,7 @@ func TestFailedUpdateFilterJob(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -385,13 +388,31 @@ func TestFailedUpdateFilterJob(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{Forbidden: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{Forbidden: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter job request forbidden\n")
+		So(response, ShouldResemble, "Forbidden, the job has been locked as it has been submitted to be processed\n")
+	})
+
+	Convey("a json message is sent to change a submitted filter with the wrong authorisation header, an unauthorised status is returned", t, func() {
+		reader := strings.NewReader("{\"state\":\"submitted\"}")
+
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+		So(err, ShouldBeNil)
+
+		r.Header.Add(internalToken, "cookie")
+
+		w := httptest.NewRecorder()
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusUnauthorized)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Unauthorised, request lacks valid authentication credentials\n")
 	})
 }
 
@@ -402,7 +423,7 @@ func TestSuccessfulGetFilterDimensions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -415,13 +436,13 @@ func TestGetFilterDimensionsFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Internal server error\n")
+		So(response, ShouldResemble, "Failed to process the request due to an internal error\n")
 	})
 
 	Convey("When filter job does not exist, a not found is returned", t, func() {
@@ -429,7 +450,7 @@ func TestGetFilterDimensionsFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -446,7 +467,7 @@ func TestSuccessfulGetFilterDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 	})
@@ -459,13 +480,13 @@ func TestGetFilterDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Internal server error\n")
+		So(response, ShouldResemble, "Failed to process the request due to an internal error\n")
 	})
 
 	Convey("When filter job does not exist, a bad request is returned", t, func() {
@@ -473,7 +494,7 @@ func TestGetFilterDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -487,7 +508,7 @@ func TestGetFilterDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -503,7 +524,7 @@ func TestSuccessfulGetFilterDimensionOptions(t *testing.T) {
 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options", nil)
 		So(err, ShouldBeNil)
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -516,13 +537,13 @@ func TestGetFilterDimensionOptionsFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Internal server error\n")
+		So(response, ShouldResemble, "Failed to process the request due to an internal error\n")
 	})
 
 	Convey("When filter job does not exist, a bad request is returned", t, func() {
@@ -530,7 +551,7 @@ func TestGetFilterDimensionOptionsFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -544,7 +565,7 @@ func TestGetFilterDimensionOptionsFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -561,7 +582,7 @@ func TestSuccessfulGetFilterDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 	})
@@ -574,13 +595,13 @@ func TestGetFilterDimensionOptionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Internal server error\n")
+		So(response, ShouldResemble, "Failed to process the request due to an internal error\n")
 	})
 
 	Convey("When filter job does not exist, a bad request is returned", t, func() {
@@ -588,7 +609,7 @@ func TestGetFilterDimensionOptionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -602,7 +623,7 @@ func TestGetFilterDimensionOptionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{OptionNotFound: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{OptionNotFound: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -619,7 +640,7 @@ func TestSuccessfulRemoveFilterDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -632,13 +653,13 @@ func TestRemoveFilterDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Internal server error\n")
+		So(response, ShouldResemble, "Failed to process the request due to an internal error\n")
 	})
 
 	Convey("When filter job does not exist, a bad request is returned", t, func() {
@@ -646,7 +667,7 @@ func TestRemoveFilterDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -660,13 +681,13 @@ func TestRemoveFilterDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{Forbidden: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{Forbidden: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter job request forbidden\n")
+		So(response, ShouldResemble, "Forbidden, the job has been locked as it has been submitted to be processed\n")
 	})
 
 	Convey("When dimension does not exist against filter job, a not found is returned", t, func() {
@@ -674,7 +695,7 @@ func TestRemoveFilterDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -691,7 +712,7 @@ func TestSuccessfulRemoveOptionDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -704,13 +725,13 @@ func TestRemoveOptionDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Internal server error\n")
+		So(response, ShouldResemble, "Failed to process the request due to an internal error\n")
 	})
 
 	Convey("When filter job does not exist, a bad request is returned", t, func() {
@@ -718,7 +739,7 @@ func TestRemoveOptionDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -732,13 +753,13 @@ func TestRemoveOptionDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{Forbidden: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{Forbidden: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter job request forbidden\n")
+		So(response, ShouldResemble, "Forbidden, the job has been locked as it has been submitted to be processed\n")
 	})
 
 	Convey("When dimension does not exist against filter job, a not found is returned", t, func() {
@@ -746,7 +767,7 @@ func TestRemoveOptionDimensionFailure(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := CreateFilterAPI(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{})
+		api := CreateFilterAPI(authHeader, host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{})
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 

--- a/api/datastore.go
+++ b/api/datastore.go
@@ -16,5 +16,5 @@ type DataStore interface {
 	GetFilterDimensionOption(filterID string, name string, option string) error
 	RemoveFilterDimension(filterID string, name string) error
 	RemoveFilterDimensionOption(filterId string, name string, option string) error
-	UpdateFilter(isAuthenticated bool, filterID string, filter *models.Filter) error
+	UpdateFilter(isAuthenticated bool, filter *models.Filter) error
 }

--- a/api/datastore.go
+++ b/api/datastore.go
@@ -14,7 +14,7 @@ type DataStore interface {
 	GetFilterDimension(filterID string, name string) error
 	GetFilterDimensionOptions(filterID string, name string) (models.GetDimensionOptions, error)
 	GetFilterDimensionOption(filterID string, name string, option string) error
-	RemoveFilterDimension(filterJobID string, name string) error
-	RemoveFilterDimensionOption(filterJobId string, name string, option string) error
-	UpdateFilter(host string, filter *models.Filter) error
+	RemoveFilterDimension(filterID string, name string) error
+	RemoveFilterDimensionOption(filterId string, name string, option string) error
+	UpdateFilter(isAuthenticated bool, filterID string, filter *models.Filter) error
 }

--- a/api/filters.go
+++ b/api/filters.go
@@ -284,7 +284,7 @@ func (api *FilterAPI) updateFilterJob(w http.ResponseWriter, r *http.Request) {
 
 	filter.FilterID = filterID
 
-	err = api.dataStore.UpdateFilter(isAuthenticated, filterID, filter)
+	err = api.dataStore.UpdateFilter(isAuthenticated, filter)
 	if err != nil {
 		log.Error(err, log.Data{"filter": filter, "filter_job_id": filterID})
 		setErrorCode(w, err)

--- a/api/filters.go
+++ b/api/filters.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/ONSdigital/dp-filter-api/models"
@@ -12,9 +13,13 @@ import (
 )
 
 var (
-	internalError = "Internal server error"
+	internalError = "Failed to process the request due to an internal error"
 	badRequest    = "Bad client request received"
+	unauthorised  = "Unauthorised, request lacks valid authentication credentials"
+	forbidden     = "Forbidden, the job has been locked as it has been submitted to be processed"
 )
+
+const internalToken = "internal_token"
 
 func (api *FilterAPI) addFilterJob(w http.ResponseWriter, r *http.Request) {
 	newFilter, err := models.CreateFilter(r.Body)
@@ -257,6 +262,7 @@ func (api *FilterAPI) addFilterJobDimensionOption(w http.ResponseWriter, r *http
 func (api *FilterAPI) updateFilterJob(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	filterID := vars["filter_job_id"]
+
 	filter, err := models.CreateFilter(r.Body)
 	if err != nil {
 		log.Error(err, log.Data{"filter_job_id": filterID})
@@ -264,9 +270,21 @@ func (api *FilterAPI) updateFilterJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	authenticationHeader := r.Header.Get(internalToken)
+
+	var isAuthenticated bool
+	if authenticationHeader != "" {
+		isAuthenticated, err = api.checkAuthentication(authenticationHeader)
+		if err != nil {
+			log.Error(err, log.Data{"filter_job_id": filterID})
+			setErrorCode(w, err)
+			return
+		}
+	}
+
 	filter.FilterID = filterID
 
-	err = api.dataStore.UpdateFilter(filterID, filter)
+	err = api.dataStore.UpdateFilter(isAuthenticated, filterID, filter)
 	if err != nil {
 		log.Error(err, log.Data{"filter": filter, "filter_job_id": filterID})
 		setErrorCode(w, err)
@@ -305,6 +323,15 @@ func (api *FilterAPI) removeFilterJobDimensionOption(w http.ResponseWriter, r *h
 	log.Info("delete filtered job", log.Data{"filter_job_id": filterID, "dimension": name})
 }
 
+func (api *FilterAPI) checkAuthentication(header string) (bool, error) {
+	if header != api.internalToken {
+		authorisationError := errors.New("Not authorised")
+		return false, authorisationError
+	}
+
+	return true, nil
+}
+
 func setJSONContentType(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 }
@@ -325,10 +352,10 @@ func setErrorCode(w http.ResponseWriter, err error) {
 		http.Error(w, "Bad request", http.StatusBadRequest)
 		return
 	case err.Error() == "Forbidden":
-		http.Error(w, "Filter job request forbidden", http.StatusForbidden)
+		http.Error(w, forbidden, http.StatusForbidden)
 		return
 	case err.Error() == "Not authorised":
-		http.Error(w, "Filter job request not authorised", http.StatusUnauthorized)
+		http.Error(w, unauthorised, http.StatusUnauthorized)
 		return
 	case err != nil:
 		http.Error(w, internalError, http.StatusInternalServerError)

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Host                    string   `env:"HOST" flag:"host" flagDesc:"The host name used to build URLs"`
 	KafkaMaxBytes           string   `env:"KAFKA_MAX_BYTES" flag:"kafka-max-bytes" flagDesc:"The maximum permitted size of a message. Should be set equal to or smaller than the broker's 'message.max.bytes'"`
 	PostgresURL             string   `env:"POSTGRES_URL" flag:"postgres-url" flagDesc:"The URL address to connect to a postgres instance'"`
+	SecretKey               string   `env:"SECRET_KEY" flag:"secret-key" flagDesc:"A secret key used authentication"`
 }
 
 var cfg *Config
@@ -27,6 +28,7 @@ func Get() (*Config, error) {
 		Host:          "http://localhost:22100",
 		KafkaMaxBytes: "2000000",
 		PostgresURL:   "user=dp dbname=FilterJobs sslmode=disable",
+		SecretKey:     "FD0108EA-825D-411C-9B1D-41EF7727F465",
 	}
 
 	if err := gofigure.Gofigure(cfg); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,6 +23,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.Brokers, ShouldResemble, []string{"localhost:9092"})
 				So(cfg.FilterJobSubmittedTopic, ShouldEqual, "filter-job-submitted-topic")
 				So(cfg.KafkaMaxBytes, ShouldEqual, "2000000")
+				So(cfg.SecretKey, ShouldEqual, "FD0108EA-825D-411C-9B1D-41EF7727F465")
 			})
 		})
 	})

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 		"bind_address": cfg.BindAddr,
 	})
 
-	_ = api.CreateFilterAPI(cfg.Host, router, dataStore, &jobQueue)
+	_ = api.CreateFilterAPI(cfg.SecretKey, cfg.Host, router, dataStore, &jobQueue)
 
 	if err = s.ListenAndServe(); err != nil {
 		log.Error(err, nil)

--- a/mocks/datastore.go
+++ b/mocks/datastore.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	internalServerError  = errors.New("DataStore internal error")
-	unauthorisedError    = errors.New("Unauthorised, request lacks valid authentication credentials")
+	unauthorisedError    = errors.New("Unauthorised")
 	badRequestError      = errors.New("Bad request")
 	forbiddenError       = errors.New("Forbidden")
 	notFoundError        = errors.New("Not found")
@@ -172,6 +172,7 @@ func (ds *DataStore) RemoveFilterDimension(string, string) error {
 
 	return nil
 }
+
 func (ds *DataStore) RemoveFilterDimensionOption(filterJobId string, name string, option string) error {
 	if ds.InternalError {
 		return internalServerError
@@ -192,7 +193,7 @@ func (ds *DataStore) RemoveFilterDimensionOption(filterJobId string, name string
 	return nil
 }
 
-func (ds *DataStore) UpdateFilter(isAuthenticated bool, filterID string, filterJob *models.Filter) error {
+func (ds *DataStore) UpdateFilter(isAuthenticated bool, filterJob *models.Filter) error {
 	if ds.InternalError {
 		return internalServerError
 	}

--- a/mocks/datastore.go
+++ b/mocks/datastore.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	internalServerError  = errors.New("DataStore internal error")
+	unauthorisedError    = errors.New("Unauthorised, request lacks valid authentication credentials")
 	badRequestError      = errors.New("Bad request")
 	forbiddenError       = errors.New("Forbidden")
 	notFoundError        = errors.New("Not found")
@@ -191,9 +192,13 @@ func (ds *DataStore) RemoveFilterDimensionOption(filterJobId string, name string
 	return nil
 }
 
-func (ds *DataStore) UpdateFilter(host string, filterJob *models.Filter) error {
+func (ds *DataStore) UpdateFilter(isAuthenticated bool, filterID string, filterJob *models.Filter) error {
 	if ds.InternalError {
 		return internalServerError
+	}
+
+	if ds.Unauthorised {
+		return unauthorisedError
 	}
 
 	if ds.BadRequest {

--- a/models/models.go
+++ b/models/models.go
@@ -23,7 +23,7 @@ type Filter struct {
 type Dimension struct {
 	DimensionURL string   `json:"dimension_url,omitempty"`
 	Name         string   `json:"name,omitempty"`
-	Values       []string `json:"values,omitempty"`
+	Options      []string `json:"options,omitempty"`
 }
 
 // Downloads represents a list of file types possible to download
@@ -116,7 +116,7 @@ func CreateDimensionOptions(reader io.Reader) ([]string, error) {
 	}
 
 	if string(bytes) == "" {
-		return dimension.Values, nil
+		return dimension.Options, nil
 	}
 
 	err = json.Unmarshal(bytes, &dimension)
@@ -124,5 +124,5 @@ func CreateDimensionOptions(reader io.Reader) ([]string, error) {
 		return nil, errors.New("Failed to parse json body")
 	}
 
-	return dimension.Values, nil
+	return dimension.Options, nil
 }

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -109,11 +109,11 @@ func (ds Datastore) AddFilterDimension(dimensionObject *models.AddDimension) err
 
 	log.Trace("dimension successfully deleted", log.Data{"filter_job_id": dimensionObject.FilterID, "dimension": dimensionObject.Name})
 
-	// Add any values against dimension
+	// Add any options against dimension
 	if len(dimensionObject.Options) > 0 {
 		dimension := models.Dimension{
-			Name:   dimensionObject.Name,
-			Values: dimensionObject.Options,
+			Name:    dimensionObject.Name,
+			Options: dimensionObject.Options,
 		}
 
 		if err = ds.createDimensionOptions(tx, dimensionObject.FilterID, dimension); err != nil {
@@ -513,8 +513,8 @@ func (ds Datastore) createDimensions(tx *sql.Tx, filterID string, dimensions []m
 
 // addDimensionOptions method adds options of a single dimension to be stored in postgres and relates it to filter job
 func (ds Datastore) createDimensionOptions(tx *sql.Tx, filterID string, dimension models.Dimension) error {
-	for _, value := range dimension.Values {
-		_, err := tx.Stmt(ds.addDimensionOption).Exec(filterID, dimension.Name, value)
+	for _, option := range dimension.Options {
+		_, err := tx.Stmt(ds.addDimensionOption).Exec(filterID, dimension.Name, option)
 		if err != nil {
 			return err
 		}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -299,12 +299,6 @@ definitions:
     - $ref: '#/definitions/JobState'
     - type: object
       properties:
-        dimensions:
-          readOnly: false
-          type: array
-          description: "A list of dimensions in the filter job"
-          items:
-             $ref: '#/definitions/DimensionOptions'
         downloads:
           readOnly: false
           type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -39,7 +39,7 @@ parameters:
     description: "A dimension to filter the dataset"
     in: body
   options:
-    required: true
+    required: false
     name: options
     schema:
       $ref: '#/definitions/Options'
@@ -422,10 +422,14 @@ definitions:
         items:
           type: string
   Options:
-    type: array
+    type: object
     description: "A list of options for dimension to filter on a dataset"
-    items:
-      type: string
+    properties:
+      options:
+        type: array
+        description: "A list of options for dimension to filter on a dataset"
+        items:
+          type: string
   Events:
     readOnly: true
     type: object


### PR DESCRIPTION
### What

Extend PUT request to handle authentication header; this allows backend services to update the filter job when the state is set to `submitted`.

Also includes: 

* Additional logic on endpoints to update filter job to prevent users updating a job if it is already completed
* Update swagger spec
* Correctly returned error messages to match swagger spec

### How to review

Run tests, make sure changes meets coding standards. Check endpoints match swagger spec; this will include error responses as well as the response models.

### Who can review

Team B
