### PR TITLE
Authenticated users allowed to update Downloads table vi 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ dp-filter-api
 | BIND_ADDR                  | :22100                                    | The host and port to bind to
 | HOST                       | http://localhost:22100                    | The host name used to build URLs
 | KAFKA_ADDR                 | localhost:9092                            | The kafka broker addresses (can be comma separated)
-| FILTER_JOB_SUBMITTED_TOPIC | filter-job-submitted-topic                | The kafka topic to write messages to
+| FILTER_JOB_SUBMITTED_TOPIC | filter-job-submitted                      | The kafka topic to write messages to
 | KAFKA_MAX_BYTES            | 2000000                | The maximum permitted size of a message. Should be set equal to or smaller than the broker's `message.max.bytes`
 | POSTGRES_URL               | user=dp dbname=FilterJobs sslmode=disable | URL to a Postgres services
 | SECRET_KEY                 | FD0108EA-825D-411C-9B1D-41EF7727F465      | A secret key used authentication

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ func Get() (*Config, error) {
 	cfg = &Config{
 		BindAddr:                ":22100",
 		Brokers:                 []string{"localhost:9092"},
-		FilterJobSubmittedTopic: "filter-job-submitted-topic",
+		FilterJobSubmittedTopic: "filter-job-submitted",
 		Host:          "http://localhost:22100",
 		KafkaMaxBytes: "2000000",
 		PostgresURL:   "user=dp dbname=FilterJobs sslmode=disable",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,7 +21,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.Host, ShouldEqual, "http://localhost:22100")
 				So(cfg.PostgresURL, ShouldEqual, "user=dp dbname=FilterJobs sslmode=disable")
 				So(cfg.Brokers, ShouldResemble, []string{"localhost:9092"})
-				So(cfg.FilterJobSubmittedTopic, ShouldEqual, "filter-job-submitted-topic")
+				So(cfg.FilterJobSubmittedTopic, ShouldEqual, "filter-job-submitted")
 				So(cfg.KafkaMaxBytes, ShouldEqual, "2000000")
 				So(cfg.SecretKey, ShouldEqual, "FD0108EA-825D-411C-9B1D-41EF7727F465")
 			})

--- a/main.go
+++ b/main.go
@@ -64,5 +64,7 @@ func main() {
 		log.Error(err, nil)
 	}
 
+	db.Close()
+
 	producer.Closer() <- true
 }

--- a/main.go
+++ b/main.go
@@ -64,7 +64,5 @@ func main() {
 		log.Error(err, nil)
 	}
 
-	db.Close()
-
 	producer.Closer() <- true
 }

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -607,19 +607,19 @@ func (ds Datastore) removeDimension(tx *sql.Tx, dimensionObject *models.AddDimen
 }
 
 func getFilterJobState(tx *sql.Tx, ds Datastore, filterID string, isAuthenticated bool) (*models.Filter, error) {
-	var filterJob *models.Filter
 	row := tx.Stmt(ds.getFilterState).QueryRow(filterID)
 
 	var filter sql.NullString
-
 	if err := row.Scan(&filter); err != nil {
 		return nil, convertError(err, "")
 	}
 
 	state := filter.String
 
-	filterJob.FilterID = filterID
-	filterJob.State = state
+	filterJob := &models.Filter{
+		FilterID: filterID,
+		State:    state,
+	}
 
 	if !isAuthenticated {
 		if state == submittedState || state == completedState {

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -632,13 +632,6 @@ func getFilterJobState(tx *sql.Tx, ds Datastore, filterID string, isAuthenticate
 	return filterJob, nil
 }
 
-type statements struct {
-	filterStatement       string
-	downloadCSVStatement  string
-	downloadJSONStatement string
-	downloadXLSStatement  string
-}
-
 func prepare(sql string, db *sql.DB) (*sql.Stmt, error) {
 	statement, err := db.Prepare(sql)
 	if err != nil {

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -167,6 +167,10 @@ func (ds Datastore) AddFilterDimensionOption(dimensionOptionObject *models.AddDi
 	}
 	defer rows.Close()
 
+	if err = rows.Err(); err != nil {
+		return convertError(err, "")
+	}
+
 	if _, err = ds.upsertDimensionOption.Exec(dimensionOptionObject.FilterID, dimensionOptionObject.Name, dimensionOptionObject.Option); err != nil {
 		return err
 	}
@@ -201,6 +205,10 @@ func (ds Datastore) GetFilter(filterID string) (models.Filter, error) {
 		return filterJob, convertError(err, "")
 	}
 	defer downloadRows.Close()
+
+	if err = downloadRows.Err(); err != nil {
+		return filterJob, convertError(err, "")
+	}
 
 	downloads := models.Downloads{}
 	for downloadRows.Next() {
@@ -248,6 +256,10 @@ func (ds Datastore) GetFilterDimensions(filterID string) ([]models.Dimension, er
 	}
 	defer dimensionRows.Close()
 
+	if err = dimensionRows.Err(); err != nil {
+		return dimensions, convertError(err, "")
+	}
+
 	for dimensionRows.Next() {
 		var name sql.NullString
 		err := dimensionRows.Scan(&name)
@@ -294,6 +306,10 @@ func (ds Datastore) GetFilterDimensionOptions(filterID string, name string) (mod
 		return options, convertError(err, "")
 	}
 	defer optionRows.Close()
+
+	if err = optionRows.Err(); err != nil {
+		return options, convertError(err, "")
+	}
 
 	var option sql.NullString
 	var optionURLs []string

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ONSdigital/dp-filter-api/models"
 	sqlmock "github.com/go-sqlmock"
+	"github.com/lib/pq"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -20,6 +20,8 @@ var (
 	getDimensionValuesSQL    = "SELECT name, value FROM Dimensions WHERE"
 	getDownloadsSQL          = "SELECT size, type, url FROM Downloads WHERE"
 	upsertDimensionOptionSQL = "INSERT INTO Dimensions(.+) VALUES(.+) ON CONSTRAINT"
+	upsertDownloadURLSQL     = "INSERT INTO Downloads(.+) VALUES(.+) ON CONSTRAINT"
+	upsertFilterStateSQL     = "UPDATE Filters SET"
 )
 
 func NewSQLMockWithSQLStatements() (sqlmock.Sqlmock, *sql.DB) {
@@ -35,6 +37,8 @@ func NewSQLMockWithSQLStatements() (sqlmock.Sqlmock, *sql.DB) {
 	mock.ExpectPrepare(getDimensionValuesSQL)
 	mock.ExpectPrepare(getDownloadsSQL)
 	mock.ExpectPrepare(upsertDimensionOptionSQL)
+	mock.ExpectPrepare(upsertDownloadURLSQL)
+	mock.ExpectPrepare(upsertFilterStateSQL)
 	_, dbError := db.Begin()
 	So(dbError, ShouldBeNil)
 	return mock, db
@@ -49,78 +53,61 @@ func TestNewPostgresDatastore(t *testing.T) {
 	})
 }
 
-func TestUpdateStatement(t *testing.T) {
-	t.Parallel()
-	Convey("when update filter job has a state in json body successfully return statement", t, func() {
-		filter := &models.Filter{
-			State: "submitted",
-		}
-
-		statement, err := updateStatement(filter)
-		So(err, ShouldBeNil)
-		So(statement, ShouldEqual, "UPDATE Filters SET state = 'submitted' WHERE filterJobId = $1 RETURNING filterJobId")
-	})
-
-	Convey("when update filter job has a state and dataset in json body successfully return statement", t, func() {
-		filter := &models.Filter{
-			DatasetFilterID: "12345678",
-			State:           "submitted",
-		}
-
-		statement, err := updateStatement(filter)
-		So(err, ShouldBeNil)
-		So(statement, ShouldEqual, "UPDATE Filters SET state = 'submitted' WHERE filterJobId = $1 RETURNING filterJobId")
-	})
-
-	Convey("when update filter job has only dataset_filter_id in json body return error", t, func() {
-		filter := &models.Filter{
-			DatasetFilterID: "12345678",
-		}
-
-		statement, err := updateStatement(filter)
-		So(err, ShouldNotBeNil)
-		So(err, ShouldResemble, fmt.Errorf("Bad request"))
-		So(statement, ShouldEqual, "")
-	})
-}
-
-func TestConvertSQLError(t *testing.T) {
+func TestConvertError(t *testing.T) {
 	t.Parallel()
 	Convey("Testing convert sql error function", t, func() {
 
 		Convey("when receiving an SQL number of rows error, successfully return \"Not found\" error", func() {
-			err := convertSQLError(sql.ErrNoRows, "")
+			err := convertError(sql.ErrNoRows, "")
 			So(err, ShouldNotBeNil)
 			So(err, ShouldResemble, errors.New("Not found"))
 		})
 
 		Convey("when receiving an SQL number of rows error and a string type of \"bad request\", successfuly return \"Bad request\" error", func() {
-			err := convertSQLError(sql.ErrNoRows, "bad request")
+			err := convertError(sql.ErrNoRows, "bad request")
 			So(err, ShouldNotBeNil)
 			So(err, ShouldResemble, errors.New("Bad request"))
 		})
 
 		Convey("when receiving an SQL number of rows error and a string type of \"dimension not found\", successfuly return \"Dimension not found\" error", func() {
-			err := convertSQLError(sql.ErrNoRows, "dimension not found")
+			err := convertError(sql.ErrNoRows, "dimension not found")
 			So(err, ShouldNotBeNil)
 			So(err, ShouldResemble, errors.New("Dimension not found"))
 		})
 
 		Convey("when receiving an SQL number of rows error and a string type of \"option not found\", successfuly return \"Option not found\" error", func() {
-			err := convertSQLError(sql.ErrNoRows, "option not found")
+			err := convertError(sql.ErrNoRows, "option not found")
 			So(err, ShouldNotBeNil)
 			So(err, ShouldResemble, errors.New("Option not found"))
 		})
 
 		Convey("when receiving a generic error (not an sql error), successfuly return same error", func() {
-			err := convertSQLError(fmt.Errorf("not an sql error"), "")
+			err := convertError(fmt.Errorf("not an sql error"), "")
 			So(err, ShouldNotBeNil)
 			So(err, ShouldResemble, errors.New("not an sql error"))
 		})
 
 		Convey("when no error is passed in, return nil", func() {
-			err := convertSQLError(nil, "")
+			err := convertError(nil, "")
 			So(err, ShouldBeNil)
+		})
+
+		Convey("when receiving a postgres error of duplicate key error, successfully return \"Bad request\" error", func() {
+			postgresError := &pq.Error{
+				Constraint: "filterjobdimensionoption",
+			}
+			err := convertError(postgresError, "")
+			So(err, ShouldNotBeNil)
+			So(err, ShouldResemble, errors.New("Bad request"))
+		})
+
+		Convey("when receiving a postgres error not due to duplicate key error, successfully return error", func() {
+			postgresError := &pq.Error{
+				Code: pq.ErrorCode("404"),
+			}
+			err := convertError(postgresError, "")
+			So(err, ShouldNotBeNil)
+			So(err, ShouldEqual, postgresError)
 		})
 	})
 }

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -6,50 +6,408 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ONSdigital/dp-filter-api/models"
 	sqlmock "github.com/go-sqlmock"
 	"github.com/lib/pq"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (
-	addFilterSQL             = "INSERT INTO Filters"
+	addFilterSQL             = "INSERT INTO Filters(.+) VALUES(.+)"
 	addDimensionSQL          = "INSERT INTO Dimensions"
-	deleteDimensionSQL       = "DELETE FROM Dimensions WHERE"
-	getFilterSQL             = "SELECT * FROM Filters WHERE"
+	addDimensionOptionSQL    = "INSERT INTO Dimensions(.+) VALUES"
+	deleteDimensionSQL       = "DELETE FROM Dimensions WHERE filterJobId = (.+) AND name = (.+)"
+	deleteDimensionOptionSQL = "DELETE FROM Dimensions WHERE filterJobId = (.+) AND name = (.+) AND option = (.+)"
+	getFilterSQL             = "SELECT (.*) FROM Filters WHERE"
 	getFilterStateSQL        = "SELECT state FROM Filters WHERE"
-	getDimensionValuesSQL    = "SELECT name, value FROM Dimensions WHERE"
-	getDownloadsSQL          = "SELECT size, type, url FROM Downloads WHERE"
+	getDimensionSQL          = "SELECT name FROM Dimensions WHERE filterJobId = (.+) AND name = (.+)"
+	getDimensionsSQL         = "SELECT name FROM Dimensions WHERE filterJobId = (.+)"
+	getDimensionOptionsSQL   = "SELECT option FROM Dimensions WHERE filterJobId = (.+) AND name = (.+)"
+	getDimensionOptionSQL    = "SELECT option FROM Dimensions WHERE filterJobId = (.+) AND name = (.+) AND option = (.+)"
+	getDownloadItemsSQL      = "SELECT size, type, url FROM Downloads WHERE"
+	updateFilterStateSQL     = "UPDATE Filters SET"
 	upsertDimensionOptionSQL = "INSERT INTO Dimensions(.+) VALUES(.+) ON CONSTRAINT"
 	upsertDownloadURLSQL     = "INSERT INTO Downloads(.+) VALUES(.+) ON CONSTRAINT"
-	upsertFilterStateSQL     = "UPDATE Filters SET"
 )
-
-func NewSQLMockWithSQLStatements() (sqlmock.Sqlmock, *sql.DB) {
-	db, mock, err := sqlmock.New()
-	So(err, ShouldBeNil)
-	mock.ExpectBegin()
-	mock.MatchExpectationsInOrder(false)
-	mock.ExpectPrepare(addFilterSQL)
-	mock.ExpectPrepare(addDimensionSQL)
-	mock.ExpectPrepare(deleteDimensionSQL)
-	mock.ExpectPrepare(getFilterSQL)
-	mock.ExpectPrepare(getFilterStateSQL)
-	mock.ExpectPrepare(getDimensionValuesSQL)
-	mock.ExpectPrepare(getDownloadsSQL)
-	mock.ExpectPrepare(upsertDimensionOptionSQL)
-	mock.ExpectPrepare(upsertDownloadURLSQL)
-	mock.ExpectPrepare(upsertFilterStateSQL)
-	_, dbError := db.Begin()
-	So(dbError, ShouldBeNil)
-	return mock, db
-}
 
 func TestNewPostgresDatastore(t *testing.T) {
 	t.Parallel()
 	Convey("When creating a postgres datastore no errors are returned", t, func() {
-		_, db := NewSQLMockWithSQLStatements()
+		mock, db := NewSQLMockWithSQLStatements()
 		_, err := NewDatastore(db)
 		So(err, ShouldBeNil)
+		So(mock.ExpectationsWereMet(), ShouldBeNil)
+	})
+}
+
+func TestAddFilter(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully create a new filter job", t, func() {
+		mock, db := NewSQLMockWithSQLStatements()
+		ds, err := NewDatastore(db)
+		So(err, ShouldBeNil)
+		mock.ExpectBegin()
+		mock.ExpectPrepare(addFilterSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectPrepare(addDimensionOptionSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectPrepare(addDimensionOptionSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit()
+
+		var dimensions []models.Dimension
+
+		dimensions = append(dimensions, models.Dimension{
+			Name:    "age",
+			Options: []string{"10", "20"},
+		})
+
+		newFilter := &models.Filter{
+			FilterID:   "123",
+			Dimensions: dimensions,
+			State:      "created",
+		}
+
+		filter, err := ds.AddFilter("80", newFilter)
+		So(err, ShouldBeNil)
+		So(mock.ExpectationsWereMet(), ShouldBeNil)
+		So(filter, ShouldNotBeNil)
+	})
+}
+
+func TestAddFilterDimensions(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully add single dimension to filter", t, func() {
+		mock, db := NewSQLMockWithSQLStatements()
+		ds, err := NewDatastore(db)
+		So(err, ShouldBeNil)
+		mock.ExpectBegin()
+		mock.ExpectPrepare(getFilterSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"filterId", "datasetFilterId", "state"}).
+				AddRow("123", "12345678", "created"))
+		mock.ExpectPrepare(deleteDimensionSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(1, 0))
+		mock.ExpectPrepare(addDimensionSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit()
+
+		dimensionObject := &models.AddDimension{
+			FilterID: "123",
+			Name:     "age",
+			Options:  []string{},
+		}
+
+		err = ds.AddFilterDimension(dimensionObject)
+		So(err, ShouldBeNil)
+		So(mock.ExpectationsWereMet(), ShouldBeNil)
+	})
+
+	Convey("Successfully add populated list of options for a dimension for filter", t, func() {
+		mock, db := NewSQLMockWithSQLStatements()
+		ds, err := NewDatastore(db)
+		So(err, ShouldBeNil)
+		mock.ExpectBegin()
+		mock.ExpectPrepare(getFilterSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"filterId", "datasetFilterId", "state"}).
+				AddRow("123", "12345678", "created"))
+		mock.ExpectPrepare(deleteDimensionSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectPrepare(addDimensionOptionSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectPrepare(addDimensionOptionSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit()
+
+		dimensionObject := &models.AddDimension{
+			FilterID: "123",
+			Name:     "age",
+			Options:  []string{"10", "20"},
+		}
+
+		err = ds.AddFilterDimension(dimensionObject)
+		So(err, ShouldBeNil)
+		So(mock.ExpectationsWereMet(), ShouldBeNil)
+	})
+}
+
+func TestAddFilterDimensionOption(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully add an option to a dimension on a filter job", t, func() {
+		mock, db := NewSQLMockWithSQLStatements()
+		ds, err := NewDatastore(db)
+		So(err, ShouldBeNil)
+		mock.ExpectPrepare(getFilterSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"filterId", "datasetFilterId", "state"}).
+				AddRow("123", "12345678", "created"))
+		mock.ExpectPrepare(getDimensionSQL).ExpectQuery().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"name"}).
+				AddRow("age"))
+		mock.ExpectPrepare(upsertDimensionOptionSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		dimensionOptionObject := &models.AddDimensionOption{
+			FilterID: "123",
+			Name:     "age",
+			Option:   "12",
+		}
+
+		err = ds.AddFilterDimensionOption(dimensionOptionObject)
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestGetFilter(t *testing.T) {
+	t.Parallel()
+	Convey("When a filterJobId is provided, the filter job is returned", t, func() {
+		mock, db := NewSQLMockWithSQLStatements()
+		ds, err := NewDatastore(db)
+		So(err, ShouldBeNil)
+		mock.ExpectBegin()
+		mock.ExpectPrepare(getFilterSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"filterJobId", "datasetFilterId", "state"}).
+				AddRow("123", "12345678", "completed"))
+		mock.ExpectPrepare(getDownloadItemsSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"size", "type", "url"}).
+				AddRow("24mb", "csv", "csv/s3url").
+				AddRow("2mb", "json", "json/s3url").
+				AddRow("30mb", "xls", "xls/s3url"))
+
+		expectedFilter := models.Filter{
+			FilterID:         "123",
+			DatasetFilterID:  "12345678",
+			State:            "completed",
+			DimensionListURL: "/filters/123/dimensions",
+			Downloads: models.Downloads{
+				CSV: models.DownloadItem{
+					Size: "24mb",
+					URL:  "csv/s3url",
+				},
+				JSON: models.DownloadItem{
+					Size: "2mb",
+					URL:  "json/s3url",
+				},
+				XLS: models.DownloadItem{
+					Size: "30mb",
+					URL:  "xls/s3url",
+				},
+			},
+		}
+
+		filter, err := ds.GetFilter("123")
+		So(err, ShouldBeNil)
+		So(filter, ShouldResemble, expectedFilter)
+		So(mock.ExpectationsWereMet(), ShouldBeNil)
+	})
+}
+
+func TestGetFilterDimensions(t *testing.T) {
+	t.Parallel()
+	Convey("When a filterJobId is provided, all dimensions for the filter job are returned", t, func() {
+		mock, db := NewSQLMockWithSQLStatements()
+		ds, err := NewDatastore(db)
+		So(err, ShouldBeNil)
+		mock.ExpectPrepare(getFilterSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"filterJobId", "datasetFilterId", "state"}).
+				AddRow("123", "12345678", "completed"))
+		mock.ExpectPrepare(getDimensionsSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"name"}).
+				AddRow("age").AddRow("time"))
+
+		var expectedDimensions []models.Dimension
+
+		dimension1 := models.Dimension{
+			DimensionURL: "/filters/123/dimensions/age",
+			Name:         "age",
+		}
+
+		dimension2 := models.Dimension{
+			DimensionURL: "/filters/123/dimensions/time",
+			Name:         "time",
+		}
+
+		expectedDimensions = append(expectedDimensions, dimension1, dimension2)
+
+		dimensions, err := ds.GetFilterDimensions("123")
+		So(err, ShouldBeNil)
+		So(dimensions, ShouldResemble, expectedDimensions)
+	})
+}
+
+func TestGetFilterDimensionOptions(t *testing.T) {
+	t.Parallel()
+	Convey("When a filterJobId and dimension name is provided, all dimensions options for the filter job are returned", t, func() {
+		mock, db := NewSQLMockWithSQLStatements()
+		ds, err := NewDatastore(db)
+		So(err, ShouldBeNil)
+		mock.ExpectPrepare(getFilterSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"filterJobId", "datasetFilterId", "state"}).
+				AddRow("123", "12345678", "created"))
+		mock.ExpectPrepare(getDimensionSQL).ExpectQuery().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"name"}).
+				AddRow("age"))
+		mock.ExpectPrepare(getDimensionOptionsSQL).ExpectQuery().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"option"}).
+				AddRow("29").AddRow("7"))
+
+		expectedDimensionOptions := models.GetDimensionOptions{
+			DimensionOptionURLs: []string{"/filters/123/dimensions/age/options/29", "/filters/123/dimensions/age/options/7"},
+		}
+
+		dimensionOptions, err := ds.GetFilterDimensionOptions("123", "age")
+		So(err, ShouldBeNil)
+		So(dimensionOptions, ShouldResemble, expectedDimensionOptions)
+	})
+}
+
+func TestGetFilterDimension(t *testing.T) {
+	t.Parallel()
+	Convey("When a filterJobId and dimension name is provided, successfully return without erroring", t, func() {
+		mock, db := NewSQLMockWithSQLStatements()
+		ds, err := NewDatastore(db)
+		So(err, ShouldBeNil)
+		mock.ExpectPrepare(getFilterSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"filterJobId", "datasetFilterId", "state"}).
+				AddRow("123", "12345678", "created"))
+		mock.ExpectPrepare(getDimensionSQL).ExpectQuery().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"name"}).
+				AddRow("age"))
+
+		err = ds.GetFilterDimension("123", "age")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestGetFilterDimensionOption(t *testing.T) {
+	t.Parallel()
+	Convey("When a filterJobId, dimension name and option are provided, successfully return without erroring", t, func() {
+		mock, db := NewSQLMockWithSQLStatements()
+		ds, err := NewDatastore(db)
+		So(err, ShouldBeNil)
+		mock.ExpectPrepare(getFilterSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"filterJobId", "datasetFilterId", "state"}).
+				AddRow("123", "12345678", "created"))
+		mock.ExpectPrepare(getDimensionSQL).ExpectQuery().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"name"}).
+				AddRow("age"))
+		mock.ExpectPrepare(getDimensionOptionSQL).ExpectQuery().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"name"}).
+				AddRow("26"))
+
+		err = ds.GetFilterDimensionOption("123", "age", "26")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestRemoveFilterDimension(t *testing.T) {
+	t.Parallel()
+	Convey("When a filterJobId and dimension name are provided, successfuly remove dimension from filter job", t, func() {
+		mock, db := NewSQLMockWithSQLStatements()
+		ds, err := NewDatastore(db)
+		So(err, ShouldBeNil)
+		mock.ExpectBegin()
+		mock.ExpectPrepare(getFilterSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"filterJobId", "datasetFilterId", "state"}).
+				AddRow("123", "12345678", "created"))
+		mock.ExpectPrepare(getDimensionSQL).ExpectQuery().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"name"}).
+				AddRow("age"))
+		mock.ExpectPrepare(deleteDimensionSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit()
+
+		err = ds.RemoveFilterDimension("123", "age")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestRemoveFilterDimensionOption(t *testing.T) {
+	t.Parallel()
+	Convey("When a filterJobId, dimension name and option are provided, successfuly remove dimension option from filter job", t, func() {
+		mock, db := NewSQLMockWithSQLStatements()
+		ds, err := NewDatastore(db)
+		So(err, ShouldBeNil)
+		mock.ExpectBegin()
+		mock.ExpectPrepare(getFilterSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"filterJobId", "datasetFilterId", "state"}).
+				AddRow("123", "12345678", "created"))
+		mock.ExpectPrepare(getDimensionSQL).ExpectQuery().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"name"}).
+				AddRow("age"))
+		mock.ExpectPrepare(deleteDimensionSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit()
+
+		err = ds.RemoveFilterDimensionOption("123", "age", "26")
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestUpdateFilter(t *testing.T) {
+	t.Parallel()
+	Convey("successfuly update filter job", t, func() {
+		Convey("when an unauthenticated user updates the state from 'created' to 'submitted'", func() {
+			mock, db := NewSQLMockWithSQLStatements()
+			ds, err := NewDatastore(db)
+			So(err, ShouldBeNil)
+			mock.ExpectBegin()
+			mock.ExpectPrepare(getFilterStateSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+				WillReturnRows(sqlmock.NewRows([]string{"state"}).
+					AddRow("created"))
+			mock.ExpectPrepare(updateFilterStateSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			mock.ExpectCommit()
+
+			filter := &models.Filter{
+				FilterID:        "123",
+				State:           "submitted",
+				DatasetFilterID: "12345678",
+			}
+
+			err = ds.UpdateFilter(false, filter)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("when an authenticated user updates downloads object", func() {
+			mock, db := NewSQLMockWithSQLStatements()
+			ds, err := NewDatastore(db)
+			So(err, ShouldBeNil)
+			mock.ExpectBegin()
+			mock.ExpectPrepare(getFilterStateSQL).ExpectQuery().WithArgs(sqlmock.AnyArg()).
+				WillReturnRows(sqlmock.NewRows([]string{"state"}).
+					AddRow("submitted"))
+			mock.ExpectPrepare(updateFilterStateSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			mock.ExpectPrepare(upsertDownloadURLSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			mock.ExpectPrepare(upsertDownloadURLSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			mock.ExpectPrepare(upsertDownloadURLSQL).ExpectExec().WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			mock.ExpectCommit()
+
+			filter := &models.Filter{
+				FilterID:        "123",
+				State:           "completed",
+				DatasetFilterID: "12345678",
+				Downloads: models.Downloads{
+					CSV: models.DownloadItem{
+						Size: "12mb",
+						URL:  "s3/csvURL",
+					},
+					JSON: models.DownloadItem{
+						Size: "4mb",
+						URL:  "s3/jsonURL",
+					},
+					XLS: models.DownloadItem{
+						Size: "40mb",
+						URL:  "s3/xlsURL",
+					},
+				},
+			}
+
+			err = ds.UpdateFilter(true, filter)
+			So(err, ShouldBeNil)
+		})
 	})
 }
 
@@ -110,4 +468,29 @@ func TestConvertError(t *testing.T) {
 			So(err, ShouldEqual, postgresError)
 		})
 	})
+}
+
+func NewSQLMockWithSQLStatements() (sqlmock.Sqlmock, *sql.DB) {
+	db, mock, err := sqlmock.New()
+	So(err, ShouldBeNil)
+	mock.ExpectBegin()
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectPrepare(addFilterSQL)
+	mock.ExpectPrepare(addDimensionSQL)
+	mock.ExpectPrepare(addDimensionOptionSQL)
+	mock.ExpectPrepare(deleteDimensionSQL)
+	mock.ExpectPrepare(deleteDimensionOptionSQL)
+	mock.ExpectPrepare(getFilterSQL)
+	mock.ExpectPrepare(getFilterStateSQL)
+	mock.ExpectPrepare(getDimensionSQL)
+	mock.ExpectPrepare(getDimensionsSQL)
+	mock.ExpectPrepare(getDimensionOptionsSQL)
+	mock.ExpectPrepare(getDimensionOptionSQL)
+	mock.ExpectPrepare(getDownloadItemsSQL)
+	mock.ExpectPrepare(updateFilterStateSQL)
+	mock.ExpectPrepare(upsertDimensionOptionSQL)
+	mock.ExpectPrepare(upsertDownloadURLSQL)
+	_, dbError := db.Begin()
+	So(dbError, ShouldBeNil)
+	return mock, db
 }

--- a/scripts/InitDatabase.sql
+++ b/scripts/InitDatabase.sql
@@ -25,4 +25,9 @@ CREATE TABLE Downloads(
 
 ALTER TABLE Dimensions
   ADD CONSTRAINT filterJobDimensionOption
-  UNIQUE (filterJobId, name, option)
+  UNIQUE (filterJobId, name, option);
+
+
+ALTER TABLE Downloads
+  ADD CONSTRAINT filterJobDownloadURL
+  UNIQUE (filterJobId, type);

--- a/vendor/github.com/ONSdigital/go-ns/handlers/requestID/handler.go
+++ b/vendor/github.com/ONSdigital/go-ns/handlers/requestID/handler.go
@@ -1,0 +1,27 @@
+package requestID
+
+import (
+	"math/rand"
+	"net/http"
+)
+
+// Handler is a wrapper which adds an X-Request-Id header if one does not yet exist
+func Handler(size int) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			requestID := req.Header.Get("X-Request-Id")
+
+			if len(requestID) == 0 {
+				b := make([]rune, size)
+				for i := range b {
+					b[i] = letters[rand.Intn(len(letters))]
+				}
+				req.Header.Set("X-Request-Id", string(b))
+			}
+
+			h.ServeHTTP(w, req)
+		})
+	}
+}

--- a/vendor/github.com/ONSdigital/go-ns/handlers/timeout/handler.go
+++ b/vendor/github.com/ONSdigital/go-ns/handlers/timeout/handler.go
@@ -1,0 +1,13 @@
+package timeout
+
+import (
+	"net/http"
+	"time"
+)
+
+// Handler implements a HTTP timeout
+func Handler(timeout time.Duration) func(h http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.TimeoutHandler(h, timeout, "timed out")
+	}
+}

--- a/vendor/github.com/ONSdigital/go-ns/server/server.go
+++ b/vendor/github.com/ONSdigital/go-ns/server/server.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/ONSdigital/go-ns/handlers/requestID"
+	"github.com/ONSdigital/go-ns/handlers/timeout"
+	"github.com/ONSdigital/go-ns/log"
+	"github.com/justinas/alice"
+)
+
+// Server is a http.Server with sensible defaults, which supports
+// configurable middleware and timeouts, and shuts down cleanly
+// on SIGINT/SIGTERM
+type Server struct {
+	http.Server
+	Middleware      map[string]alice.Constructor
+	MiddlewareOrder []string
+	Alice           *alice.Chain
+	CertFile        string
+	KeyFile         string
+}
+
+// New creates a new server
+func New(bindAddr string, router http.Handler) *Server {
+	middleware := map[string]alice.Constructor{
+		"RequestID": requestID.Handler(16),
+		"Log":       log.Handler,
+		"Timeout":   timeout.Handler(10 * time.Second),
+	}
+
+	return &Server{
+		Alice:           nil,
+		Middleware:      middleware,
+		MiddlewareOrder: []string{"RequestID", "Log", "Timeout"},
+		Server: http.Server{
+			Handler:           router,
+			Addr:              bindAddr,
+			ReadTimeout:       5 * time.Second,
+			WriteTimeout:      10 * time.Second,
+			ReadHeaderTimeout: 0,
+			IdleTimeout:       0,
+			MaxHeaderBytes:    0,
+		},
+	}
+}
+
+func (s *Server) prep() {
+	var m []alice.Constructor
+	for _, v := range s.MiddlewareOrder {
+		if mw, ok := s.Middleware[v]; ok {
+			m = append(m, mw)
+			continue
+		}
+		panic("middleware not found: " + v)
+	}
+
+	s.Server.Handler = alice.New(m...).Then(s.Handler)
+}
+
+// ListenAndServe sets up SIGINT/SIGTERM signals, builds the middleware
+// chain, and creates/starts a http.Server instance
+//
+// If CertFile/KeyFile are both set, the http.Server instance is started
+// using ListenAndServeTLS. Otherwise ListenAndServe is used.
+//
+// Specifying one of CertFile/KeyFile without the other will panic.
+func (s *Server) ListenAndServe() error {
+	s.prep()
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, os.Kill)
+
+	if len(s.CertFile) > 0 || len(s.KeyFile) > 0 {
+		if len(s.CertFile) == 0 || len(s.KeyFile) == 0 {
+			panic("either CertFile/KeyFile must be blank, or both provided")
+		}
+		go func() {
+			if err := s.Server.ListenAndServeTLS(s.CertFile, s.KeyFile); err != nil {
+				log.Error(err, nil)
+				os.Exit(1)
+			}
+		}()
+	} else {
+		go func() {
+			if err := s.Server.ListenAndServe(); err != nil {
+				log.Error(err, nil)
+				os.Exit(1)
+			}
+		}()
+	}
+
+	<-stop
+	return s.Shutdown(nil)
+}
+
+// ListenAndServeTLS sets KeyFile and CertFile, then calls ListenAndServe
+func (s *Server) ListenAndServeTLS(certFile, keyFile string) error {
+	s.KeyFile = keyFile
+	s.CertFile = certFile
+	return s.ListenAndServe()
+}

--- a/vendor/github.com/justinas/alice/LICENSE
+++ b/vendor/github.com/justinas/alice/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Justinas Stankevicius
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/justinas/alice/README.md
+++ b/vendor/github.com/justinas/alice/README.md
@@ -1,0 +1,98 @@
+# Alice 
+
+[![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](http://godoc.org/github.com/justinas/alice)
+[![Build Status](https://travis-ci.org/justinas/alice.svg?branch=master)](https://travis-ci.org/justinas/alice)
+[![Coverage](http://gocover.io/_badge/github.com/justinas/alice)](http://gocover.io/github.com/justinas/alice)
+
+Alice provides a convenient way to chain 
+your HTTP middleware functions and the app handler.
+
+In short, it transforms
+
+```go
+Middleware1(Middleware2(Middleware3(App)))
+```
+
+to
+
+```go
+alice.New(Middleware1, Middleware2, Middleware3).Then(App)
+```
+
+### Why?
+
+None of the other middleware chaining solutions
+behaves exactly like Alice.
+Alice is as minimal as it gets:
+in essence, it's just a for loop that does the wrapping for you.
+
+Check out [this blog post](http://justinas.org/alice-painless-middleware-chaining-for-go/)
+for explanation how Alice is different from other chaining solutions.
+
+### Usage
+
+Your middleware constructors should have the form of
+
+```go
+func (http.Handler) http.Handler
+```
+
+Some middleware provide this out of the box.
+For ones that don't, it's trivial to write one yourself.
+
+```go
+func myStripPrefix(h http.Handler) http.Handler {
+    return http.StripPrefix("/old", h)
+}
+```
+
+This complete example shows the full power of Alice.
+
+```go
+package main
+
+import (
+    "net/http"
+    "time"
+
+    "github.com/throttled/throttled"
+    "github.com/justinas/alice"
+    "github.com/justinas/nosurf"
+)
+
+func timeoutHandler(h http.Handler) http.Handler {
+    return http.TimeoutHandler(h, 1*time.Second, "timed out")
+}
+
+func myApp(w http.ResponseWriter, r *http.Request) {
+    w.Write([]byte("Hello world!"))
+}
+
+func main() {
+    th := throttled.Interval(throttled.PerSec(10), 1, &throttled.VaryBy{Path: true}, 50)
+    myHandler := http.HandlerFunc(myApp)
+
+    chain := alice.New(th.Throttle, timeoutHandler, nosurf.NewPure).Then(myHandler)
+    http.ListenAndServe(":8000", chain)
+}
+```
+
+Here, the request will pass [throttled](https://github.com/PuerkitoBio/throttled) first,
+then an http.TimeoutHandler we've set up,
+then [nosurf](https://github.com/justinas/nosurf)
+and will finally reach our handler.
+
+Note that Alice makes **no guarantees** for
+how one or another piece of  middleware will behave.
+Once it passes the execution to the outer layer of middleware,
+it has no saying in whether middleware will execute the inner handlers.
+This is intentional behavior.
+
+Alice works with Go 1.0 and higher.
+
+### Contributing
+
+0. Find an issue that bugs you / open a new one.
+1. Discuss.
+2. Branch off, commit, test.
+3. Make a pull request / attach the commits to the issue.

--- a/vendor/github.com/justinas/alice/chain.go
+++ b/vendor/github.com/justinas/alice/chain.go
@@ -1,0 +1,112 @@
+// Package alice provides a convenient way to chain http handlers.
+package alice
+
+import "net/http"
+
+// A constructor for a piece of middleware.
+// Some middleware use this constructor out of the box,
+// so in most cases you can just pass somepackage.New
+type Constructor func(http.Handler) http.Handler
+
+// Chain acts as a list of http.Handler constructors.
+// Chain is effectively immutable:
+// once created, it will always hold
+// the same set of constructors in the same order.
+type Chain struct {
+	constructors []Constructor
+}
+
+// New creates a new chain,
+// memorizing the given list of middleware constructors.
+// New serves no other function,
+// constructors are only called upon a call to Then().
+func New(constructors ...Constructor) Chain {
+	return Chain{append(([]Constructor)(nil), constructors...)}
+}
+
+// Then chains the middleware and returns the final http.Handler.
+//     New(m1, m2, m3).Then(h)
+// is equivalent to:
+//     m1(m2(m3(h)))
+// When the request comes in, it will be passed to m1, then m2, then m3
+// and finally, the given handler
+// (assuming every middleware calls the following one).
+//
+// A chain can be safely reused by calling Then() several times.
+//     stdStack := alice.New(ratelimitHandler, csrfHandler)
+//     indexPipe = stdStack.Then(indexHandler)
+//     authPipe = stdStack.Then(authHandler)
+// Note that constructors are called on every call to Then()
+// and thus several instances of the same middleware will be created
+// when a chain is reused in this way.
+// For proper middleware, this should cause no problems.
+//
+// Then() treats nil as http.DefaultServeMux.
+func (c Chain) Then(h http.Handler) http.Handler {
+	if h == nil {
+		h = http.DefaultServeMux
+	}
+
+	for i := range c.constructors {
+		h = c.constructors[len(c.constructors)-1-i](h)
+	}
+
+	return h
+}
+
+// ThenFunc works identically to Then, but takes
+// a HandlerFunc instead of a Handler.
+//
+// The following two statements are equivalent:
+//     c.Then(http.HandlerFunc(fn))
+//     c.ThenFunc(fn)
+//
+// ThenFunc provides all the guarantees of Then.
+func (c Chain) ThenFunc(fn http.HandlerFunc) http.Handler {
+	if fn == nil {
+		return c.Then(nil)
+	}
+	return c.Then(fn)
+}
+
+// Append extends a chain, adding the specified constructors
+// as the last ones in the request flow.
+//
+// Append returns a new chain, leaving the original one untouched.
+//
+//     stdChain := alice.New(m1, m2)
+//     extChain := stdChain.Append(m3, m4)
+//     // requests in stdChain go m1 -> m2
+//     // requests in extChain go m1 -> m2 -> m3 -> m4
+func (c Chain) Append(constructors ...Constructor) Chain {
+	newCons := make([]Constructor, 0, len(c.constructors)+len(constructors))
+	newCons = append(newCons, c.constructors...)
+	newCons = append(newCons, constructors...)
+
+	return Chain{newCons}
+}
+
+// Extend extends a chain by adding the specified chain
+// as the last one in the request flow.
+//
+// Extend returns a new chain, leaving the original one untouched.
+//
+//     stdChain := alice.New(m1, m2)
+//     ext1Chain := alice.New(m3, m4)
+//     ext2Chain := stdChain.Extend(ext1Chain)
+//     // requests in stdChain go  m1 -> m2
+//     // requests in ext1Chain go m3 -> m4
+//     // requests in ext2Chain go m1 -> m2 -> m3 -> m4
+//
+// Another example:
+//  aHtmlAfterNosurf := alice.New(m2)
+// 	aHtml := alice.New(m1, func(h http.Handler) http.Handler {
+// 		csrf := nosurf.New(h)
+// 		csrf.SetFailureHandler(aHtmlAfterNosurf.ThenFunc(csrfFail))
+// 		return csrf
+// 	}).Extend(aHtmlAfterNosurf)
+//		// requests to aHtml hitting nosurfs success handler go m1 -> nosurf -> m2 -> target-handler
+//		// requests to aHtml hitting nosurfs failure handler go m1 -> nosurf -> m2 -> csrfFail
+func (c Chain) Extend(chain Chain) Chain {
+	return c.Append(chain.constructors...)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,6 +9,18 @@
 			"revisionTime": "2017-07-28T08:24:17Z"
 		},
 		{
+			"checksumSHA1": "J9OiPnhPHFPhQ+R+dq6LFj+dTxE=",
+			"path": "github.com/ONSdigital/go-ns/handlers/requestID",
+			"revision": "c493b1568574c9720d7805f23ce6271ac445dc57",
+			"revisionTime": "2017-07-28T08:24:17Z"
+		},
+		{
+			"checksumSHA1": "HgL/HLG5D1WNPb1lrb/hpywtm9o=",
+			"path": "github.com/ONSdigital/go-ns/handlers/timeout",
+			"revision": "c493b1568574c9720d7805f23ce6271ac445dc57",
+			"revisionTime": "2017-07-28T08:24:17Z"
+		},
+		{
 			"checksumSHA1": "dF3c6fF99+C/Y09aqUqJ9ouiHPE=",
 			"path": "github.com/ONSdigital/go-ns/kafka",
 			"revision": "c493b1568574c9720d7805f23ce6271ac445dc57",
@@ -17,6 +29,12 @@
 		{
 			"checksumSHA1": "AjbjbhFVAOP/1NU5HL+uy+X/yJo=",
 			"path": "github.com/ONSdigital/go-ns/log",
+			"revision": "c493b1568574c9720d7805f23ce6271ac445dc57",
+			"revisionTime": "2017-07-28T08:24:17Z"
+		},
+		{
+			"checksumSHA1": "iz7DRbcFPAK2UUXpmFs2byjTwm0=",
+			"path": "github.com/ONSdigital/go-ns/server",
 			"revision": "c493b1568574c9720d7805f23ce6271ac445dc57",
 			"revisionTime": "2017-07-28T08:24:17Z"
 		},
@@ -104,6 +122,13 @@
 			"path": "github.com/jtolds/gls",
 			"revision": "77f18212c9c7edc9bd6a33d383a7b545ce62f064",
 			"revisionTime": "2017-05-03T22:40:06Z"
+		},
+		{
+			"checksumSHA1": "OBvAHqWjdI4NQVAqTkcQAdTuCFY=",
+			"origin": "github.com/ONSdigital/go-ns/vendor/github.com/justinas/alice",
+			"path": "github.com/justinas/alice",
+			"revision": "c493b1568574c9720d7805f23ce6271ac445dc57",
+			"revisionTime": "2017-07-28T08:24:17Z"
 		},
 		{
 			"checksumSHA1": "Wh2YCiWY/VIAEEQGLS7sMB9isXk=",


### PR DESCRIPTION
### What

Update PUT endpoint `/filters/<filter_job_id>` to allow Downloads table to be updated by authenticated users. 

If authentication fails return error status 401 (unauthenticated), if auth token is not set in header of request and the filter job has been submitted then error status returned is 403 (forbidden) otherwise returns a 400 (bad request) when a user trys to update downloads table.

Also includes:

* Fix idle connections, these were previously not being closed on calling external Query method.

### How to review

Run tests, make sure changes meets coding standards. Check endpoints match swagger spec; this will include error responses as well as the response models.

### Who can review

Team B
