### PR TITLE
Fix inconsistent error responses and swagger spec

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -61,7 +61,7 @@ func TestAddFilterFailure(t *testing.T) {
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad client request received\n")
+		So(response, ShouldResemble, "Bad request - Invalid request body\n")
 	})
 
 	Convey("When a empty json message is sent, a bad request is returned", t, func() {
@@ -76,7 +76,7 @@ func TestAddFilterFailure(t *testing.T) {
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad client request received\n")
+		So(response, ShouldResemble, "Bad request - Invalid request body\n")
 	})
 
 	Convey("When a json message is missing mandatory fields, a bad request is returned", t, func() {
@@ -91,7 +91,7 @@ func TestAddFilterFailure(t *testing.T) {
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad client request received\n")
+		So(response, ShouldResemble, "Bad request - Invalid request body\n")
 	})
 }
 
@@ -160,7 +160,7 @@ func TestAddFilterJobDimensionFailure(t *testing.T) {
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad client request received\n")
+		So(response, ShouldResemble, "Bad request - Invalid request body\n")
 	})
 
 	Convey("When a filter job does not exist, a not found is returned", t, func() {
@@ -190,7 +190,7 @@ func TestAddFilterJobDimensionFailure(t *testing.T) {
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Forbidden, the job has been locked as it has been submitted to be processed\n")
+		So(response, ShouldResemble, "Forbidden, the filter job has been locked as it has been submitted to be processed\n")
 	})
 }
 
@@ -248,7 +248,7 @@ func TestAddFilterJobDimensionOptionFailure(t *testing.T) {
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Forbidden, the job has been locked as it has been submitted to be processed\n")
+		So(response, ShouldResemble, "Forbidden, the filter job has been locked as it has been submitted to be processed\n")
 	})
 
 	Convey("When a dimension for filter job does not exist, a not found status is returned", t, func() {
@@ -334,7 +334,7 @@ func TestFailedUpdateFilterJob(t *testing.T) {
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad client request received\n")
+		So(response, ShouldResemble, "Bad request - Invalid request body\n")
 	})
 
 	Convey("When a empty json message is sent, a bad request is returned", t, func() {
@@ -394,7 +394,7 @@ func TestFailedUpdateFilterJob(t *testing.T) {
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Forbidden, the job has been locked as it has been submitted to be processed\n")
+		So(response, ShouldResemble, "Forbidden, the filter job has been locked as it has been submitted to be processed\n")
 	})
 
 	Convey("a json message is sent to change a submitted filter with the wrong authorisation header, an unauthorised status is returned", t, func() {
@@ -687,7 +687,7 @@ func TestRemoveFilterDimensionFailure(t *testing.T) {
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Forbidden, the job has been locked as it has been submitted to be processed\n")
+		So(response, ShouldResemble, "Forbidden, the filter job has been locked as it has been submitted to be processed\n")
 	})
 
 	Convey("When dimension does not exist against filter job, a not found is returned", t, func() {
@@ -759,7 +759,7 @@ func TestRemoveOptionDimensionFailure(t *testing.T) {
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Forbidden, the job has been locked as it has been submitted to be processed\n")
+		So(response, ShouldResemble, "Forbidden, the filter job has been locked as it has been submitted to be processed\n")
 	})
 
 	Convey("When dimension does not exist against filter job, a not found is returned", t, func() {

--- a/api/datastore.go
+++ b/api/datastore.go
@@ -12,7 +12,7 @@ type DataStore interface {
 	GetFilter(filterID string) (models.Filter, error)
 	GetFilterDimensions(filterID string) ([]models.Dimension, error)
 	GetFilterDimension(filterID string, name string) error
-	GetFilterDimensionOptions(filterID string, name string) (models.GetDimensionOptions, error)
+	GetFilterDimensionOptions(filterID string, name string) ([]models.DimensionOption, error)
 	GetFilterDimensionOption(filterID string, name string, option string) error
 	RemoveFilterDimension(filterID string, name string) error
 	RemoveFilterDimensionOption(filterId string, name string, option string) error

--- a/api/filters.go
+++ b/api/filters.go
@@ -45,7 +45,9 @@ func (api *FilterAPI) addFilterJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO Remove new filter job dimensions AND add dimension url
+	// Remove new filter job dimensions and build dimension url
+	filterJob.Dimensions = nil
+	filterJob.DimensionListURL = "/filters/" + filterJob.FilterID + "/dimensions"
 
 	bytes, err := json.Marshal(filterJob)
 	if err != nil {

--- a/api/filters.go
+++ b/api/filters.go
@@ -56,6 +56,13 @@ func (api *FilterAPI) addFilterJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if filterJob.State == "submitted" {
+
+		api.jobQueue.Queue(&filterJob)
+
+		log.Info("filter job message sent to kafka", log.Data{"filter_job_id": filterJob.FilterID})
+	}
+
 	setJSONContentType(w)
 	w.WriteHeader(http.StatusCreated)
 	_, err = w.Write(bytes)

--- a/api/filters.go
+++ b/api/filters.go
@@ -14,9 +14,9 @@ import (
 
 var (
 	internalError = "Failed to process the request due to an internal error"
-	badRequest    = "Bad client request received"
+	badRequest    = "Bad request - Invalid request body"
 	unauthorised  = "Unauthorised, request lacks valid authentication credentials"
-	forbidden     = "Forbidden, the job has been locked as it has been submitted to be processed"
+	forbidden     = "Forbidden, the filter job has been locked as it has been submitted to be processed"
 )
 
 const internalToken = "internal_token"
@@ -44,6 +44,8 @@ func (api *FilterAPI) addFilterJob(w http.ResponseWriter, r *http.Request) {
 		setErrorCode(w, err)
 		return
 	}
+
+	// TODO Remove new filter job dimensions AND add dimension url
 
 	bytes, err := json.Marshal(filterJob)
 	if err != nil {
@@ -347,6 +349,12 @@ func setErrorCode(w http.ResponseWriter, err error) {
 		return
 	case err.Error() == "Option not found":
 		http.Error(w, "Option not found", http.StatusNotFound)
+		return
+	case err.Error() == "Bad request - filter job not found":
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	case err.Error() == "Bad request - dimension not found":
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	case err.Error() == "Bad request":
 		http.Error(w, "Bad request", http.StatusBadRequest)

--- a/mocks/datastore.go
+++ b/mocks/datastore.go
@@ -84,11 +84,11 @@ func (ds *DataStore) GetFilterDimensions(filterID string) ([]models.Dimension, e
 	dimensions := []models.Dimension{}
 
 	if ds.NotFound {
-		return dimensions, notFoundError
+		return nil, notFoundError
 	}
 
 	if ds.InternalError {
-		return dimensions, internalServerError
+		return nil, internalServerError
 	}
 
 	dimensions = append(dimensions, models.Dimension{Name: "1_age", DimensionURL: "/filters/123/dimensions/1_age"})
@@ -112,27 +112,29 @@ func (ds *DataStore) GetFilterDimension(filterID string, name string) error {
 	return nil
 }
 
-func (ds *DataStore) GetFilterDimensionOptions(filterID string, name string) (models.GetDimensionOptions, error) {
+func (ds *DataStore) GetFilterDimensionOptions(filterID string, name string) ([]models.DimensionOption, error) {
 	var (
-		options    models.GetDimensionOptions
-		optionURLs []string
+		options []models.DimensionOption
 	)
 
 	if ds.BadRequest {
-		return options, badRequestError
+		return nil, badRequestError
 	}
 
 	if ds.DimensionNotFound {
-		return options, dimensionionNotFound
+		return nil, dimensionionNotFound
 	}
 
 	if ds.InternalError {
-		return options, internalServerError
+		return nil, internalServerError
 	}
 
-	optionURLs = append(optionURLs, "/filters/123/dimensions/1_age/options/26")
+	option := models.DimensionOption{
+		DimensionOptionURL: "/filters/123/dimensions/1_age/options/26",
+		Option:             "26",
+	}
 
-	options.DimensionOptionURLs = optionURLs
+	options = append(options, option)
 
 	return options, nil
 }

--- a/models/models.go
+++ b/models/models.go
@@ -67,9 +67,10 @@ type AddDimensionOption struct {
 	Option   string
 }
 
-// GetDimensionOptions represents an array of urls for a dimension options returned on a GET request
-type GetDimensionOptions struct {
-	DimensionOptionURLs []string `json:"dimension_option_urls"`
+// DimensionOption represents dimension option information
+type DimensionOption struct {
+	DimensionOptionURL string `json:"dimension_option_url"`
+	Option             string `json:"option"`
 }
 
 // Validate checks the content of the filter structure

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -251,9 +251,19 @@ func TestGetFilterDimensionOptions(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"option"}).
 				AddRow("29").AddRow("7"))
 
-		expectedDimensionOptions := models.GetDimensionOptions{
-			DimensionOptionURLs: []string{"/filters/123/dimensions/age/options/29", "/filters/123/dimensions/age/options/7"},
+		var expectedDimensionOptions []models.DimensionOption
+
+		option1 := models.DimensionOption{
+			DimensionOptionURL: "/filters/123/dimensions/age/options/29",
+			Option:             "29",
 		}
+
+		option2 := models.DimensionOption{
+			DimensionOptionURL: "/filters/123/dimensions/age/options/7",
+			Option:             "7",
+		}
+
+		expectedDimensionOptions = append(expectedDimensionOptions, option1, option2)
 
 		dimensionOptions, err := ds.GetFilterDimensionOptions("123", "age")
 		So(err, ShouldBeNil)
@@ -430,10 +440,16 @@ func TestConvertError(t *testing.T) {
 			So(err, ShouldResemble, errors.New("Not found"))
 		})
 
-		Convey("when receiving an SQL number of rows error and a string type of \"bad request\", successfuly return \"Bad request\" error", func() {
-			err := convertError(sql.ErrNoRows, "bad request")
+		Convey("when receiving an SQL number of rows error and a string type of \"filter job not found\", successfuly return \"Bad request\" error", func() {
+			err := convertError(sql.ErrNoRows, "filter job not found")
 			So(err, ShouldNotBeNil)
-			So(err, ShouldResemble, errors.New("Bad request"))
+			So(err, ShouldResemble, errors.New("Bad request - filter job not found"))
+		})
+
+		Convey("when receiving an SQL number of rows error and a string type of \"bad request - dimension not found\", successfuly return \"Bad request\" error", func() {
+			err := convertError(sql.ErrNoRows, "bad request - dimension not found")
+			So(err, ShouldNotBeNil)
+			So(err, ShouldResemble, errors.New("Bad request - dimension not found"))
 		})
 
 		Convey("when receiving an SQL number of rows error and a string type of \"dimension not found\", successfuly return \"Dimension not found\" error", func() {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -132,12 +132,9 @@ paths:
         200:
           description: "A list of dimension URLs"
           schema:
-            type: object
-            properties:
-              dimensions:
-                type: array
-                items:
-                  $ref: '#/definitions/Dimension'
+            type: array
+            items:
+              $ref: '#/definitions/Dimension'
         404:
           $ref: '#/responses/FilterJobNotFound'
         500:
@@ -173,14 +170,11 @@ paths:
         201:
           description: "The dimension was created"
         400:
-          description: |
-            This error code could be one or more of:
-            * Invalid request body
-            * Filter job was not found
+          description: "Invalid request body"
         403:
-          description: Forbidden, the filter job has been locked as it has been `submitted` to be processed
+          description: "Forbidden, the filter job has been locked as it has been `submitted` to be processed"
         404:
-          description: "Dimension name not found"
+          description: "Filter job was not found"
         500:
           $ref: '#/responses/InternalError'
     delete:
@@ -212,7 +206,9 @@ paths:
         200:
           description: "A list of all options for a dimension was returned"
           schema:
-            $ref: '#/definitions/ListOptions'
+            type: array
+            items:
+              $ref: '#/definitions/Option'
         400:
           description: "Filter job was not found"
         404:
@@ -406,15 +402,16 @@ definitions:
         $ref: '#/definitions/DownloadFile'
       csv:
         $ref: '#/definitions/DownloadFile'
-  ListOptions:
+  Option:
     type: object
-    description: "A list of options for a dimension to filter on a dataset. Information on a dimension option can be gathered using the `Dataset API`"
+    description: "An option for a dimension to filter on a dataset. Information on a dimension option can be gathered using the `Dataset API`"
     properties:
-      dimension_option_urls:
-        type: array
-        description: "A link to the filtered options within dimension"
-        items:
-          type: string
+      dimension_option_url:
+        type: string
+        description: "A link to a filtered dimension option"
+      option:
+        type: string
+        description: "The filtered dimension option"
   Options:
     type: object
     description: "A list of options for dimension to filter on a dataset"


### PR DESCRIPTION
### What

Includes the following: 
* General tidy up of response messages when request fails.
* Update response body for GET request on `/filters/<filter_job_id>/dimensions/<name>/options` to return an array of option objects containing the dimension option url and the option value.
* Update response body for POST request on `/filters` to return `dimension_url` and NOT return dimension object.

### How to review

Check code matches swagger specs. Changes adhere to coding standards. Check tests still pass by running `make test`. 

### Who can review

Team A or Team B
