### PR TITLE
Handle different error status's in responses from dataset API

### DIFF
--- a/api/filters.go
+++ b/api/filters.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"fmt"
+
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -369,6 +370,9 @@ func setErrorCode(w http.ResponseWriter, err error) {
 		return
 	case err.Error() == "Option not found":
 		http.Error(w, "Option not found", http.StatusNotFound)
+		return
+	case err.Error() == "Instance not found":
+		http.Error(w, "Instance not found", http.StatusNotFound)
 		return
 	case err.Error() == "Bad request - filter job not found":
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/mocks/datasetapi.go
+++ b/mocks/datasetapi.go
@@ -2,18 +2,33 @@ package mocks
 
 import (
 	"context"
+	"errors"
 
 	"github.com/ONSdigital/dp-filter-api/models"
 	"github.com/ONSdigital/go-ns/rchttp"
 )
 
 type DatasetAPI struct {
+	InstanceNotFound    bool
+	InternalServerError bool
 }
+
+var (
+	instanceNotFoundError = errors.New("Instance not found")
+)
 
 func NewDatasetAPI(client *rchttp.Client, url, token string) *DatasetAPI {
 	return &DatasetAPI{}
 }
 
 func (ds *DatasetAPI) GetInstance(ctx context.Context, id string) (*models.Instance, error) {
+	if ds.InternalServerError {
+		return nil, internalServerError
+	}
+
+	if ds.InstanceNotFound {
+		return nil, instanceNotFoundError
+	}
+
 	return &models.Instance{}, nil
 }

--- a/models/instance.go
+++ b/models/instance.go
@@ -2,6 +2,7 @@ package models
 
 type Instance struct {
 	Links InstanceLinks `json:"links,omitempty"`
+	State string        `json:"state,omitempty"`
 }
 type InstanceLinks struct {
 	Version LinkObject `bson:"version,omitempty"   json:"version"`


### PR DESCRIPTION
### What

Handle different error status's in responses from dataset API. Also prevent users from filtering unpublished datasets.

### How to review

Check logic and tests still pass

### Who can review

Team B
