### PR TITLE
Fix update filter mongo query to only set limited fields

### DIFF
--- a/mongo/filterstore.go
+++ b/mongo/filterstore.go
@@ -120,7 +120,8 @@ func (s *FilterStore) UpdateFilter(isAuthenticated bool, updatedFilter *models.F
 	}
 
 	query := bson.M{"filter_job_id": updatedFilter.FilterID}
-	if err = session.DB(database).C(filtersCollection).Update(query, &updatedFilter); err != nil {
+	update := bson.M{"$set": bson.M{"downloads": updatedFilter.Downloads, "state": updatedFilter.State}}
+	if err = session.DB(database).C(filtersCollection).Update(query, &update); err != nil {
 		if err == mgo.ErrNotFound {
 			return errNotFound
 		}

--- a/mongo/filterstore.go
+++ b/mongo/filterstore.go
@@ -115,7 +115,7 @@ func (s *FilterStore) UpdateFilter(isAuthenticated bool, updatedFilter *models.F
 	}
 
 	// Don't bother checking for JSON as it doesn't get generated at the moment
-	if updatedFilter.Downloads.CSV.URL == "" && updatedFilter.Downloads.XLS.URL == "" {
+	if updatedFilter.Downloads.CSV.URL != "" && updatedFilter.Downloads.XLS.URL != "" {
 		updatedFilter.State = completed
 	}
 


### PR DESCRIPTION
### What

Updated a mongo query so that it only writes selected fields rather than overwriting entire document

### How to review

Ensure when updating the filter (particularly from 'created' to 'submitted') that dimensions dont get removed, download links get added, and state updates to completed.

### Who can review

Anyone
