### PR TITLE
Updated swagger sepc for filter preview

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -286,6 +286,27 @@ paths:
           description: "Dimension option was not found"
         500:
           $ref: '#/responses/InternalError'
+  /filters/{filter_id}/preview:
+    parameters:
+      - $ref: '#/parameters/filter_id'
+    get:
+      tags:
+      - "Public"
+      summary: "Get a preview of the current state of the filter"
+      description: "Get a preview of up to 20 observations using the current state of the filter job. It could be possible no results are returned due to data sparsity."
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "A preview of the current filter state has been returned"
+          schema:
+            $ref: '#/definitions/Preview'
+        400:
+          description: "No dimensions are present in the filter blue print"
+        404:
+          description: "The filter id was not found"
+        500:
+          $ref: '#/responses/InternalError'
   /filter-outputs/{filter_id}:
     parameters:
       - $ref: '#/parameters/filter_id'
@@ -540,4 +561,34 @@ definitions:
           id:
             description: "An ID of the version being filtered"
             example: "de3bc0b6-d6c4-4e20-917e-95d7ea8c91dc"
+            type: string
+      preview:
+        type: object
+        properties:
+          href:
+            description: "A URL to a preview of the current filter"
+            example: "http://localhost:8080/filters/DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC/preview"
+            type: string
+  Preview:
+    description: "A preview of the current filter state"
+    readOnly: true
+    type: object
+    properties:
+      headers:
+        description: "A list of all headers in the dataset"
+        type: array
+        items:
+          type: string
+      number_of_rows:
+        description: "The number of rows, this can be in the range of 0 - 20"
+        type: integer
+      number_of_columns:
+        description: "The number of columns"
+        type: integer
+      rows:
+        description: "A list of all rows for the preview as a two dimensional array"
+        type: array
+        items:
+          type: array
+          items:
             type: string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -350,7 +350,7 @@ paths:
           schema:
             $ref: '#/definitions/Preview'
         400:
-          description: "No dimensions are present in the filter blue print"
+          description: "No dimensions are present in the filter output"
         404:
           description: "The filter id was not found"
         500:
@@ -572,8 +572,8 @@ definitions:
         type: object
         properties:
           href:
-            description: "A URL to a preview of the current filter"
-            example: "http://localhost:8080/filters/DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC/preview"
+            description: "A URL to a preview of the filter output"
+            example: "http://localhost:8080/filter-outputs/DE3BC0B6-D6C4-4E20-917E-95D7EA8C91DC/preview"
             type: string
   Preview:
     description: "A preview of the current filter state"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -27,6 +27,11 @@ parameters:
     required: true
     description: "The unique filter outer ID for customising a dataset"
     in: path
+  limit:
+    name: limit
+    type: integer
+    description: "Limit the number of rows returned in a preview. Defaults to 20 and capped at 100"
+    in: query
   name:
     name: name
     type: string
@@ -286,27 +291,6 @@ paths:
           description: "Dimension option was not found"
         500:
           $ref: '#/responses/InternalError'
-  /filters/{filter_id}/preview:
-    parameters:
-      - $ref: '#/parameters/filter_id'
-    get:
-      tags:
-      - "Public"
-      summary: "Get a preview of the current state of the filter"
-      description: "Get a preview of up to 20 observations using the current state of the filter job. It could be possible no results are returned due to data sparsity."
-      produces:
-      - "application/json"
-      responses:
-        200:
-          description: "A preview of the current filter state has been returned"
-          schema:
-            $ref: '#/definitions/Preview'
-        400:
-          description: "No dimensions are present in the filter blue print"
-        404:
-          description: "The filter id was not found"
-        500:
-          $ref: '#/responses/InternalError'
   /filter-outputs/{filter_id}:
     parameters:
       - $ref: '#/parameters/filter_id'
@@ -347,6 +331,28 @@ paths:
           description: "Forbidden, the filter output state has been set to `completed`, resource has a list of downloadable files"
         404:
           $ref: '#/responses/FilterOutputNotFound'
+        500:
+          $ref: '#/responses/InternalError'
+  /filter-outputs/{filter_id}/preview:
+    parameters:
+      - $ref: '#/parameters/filter_id'
+      - $ref: '#/parameters/limit'
+    get:
+      tags:
+      - "Public"
+      summary: "Get a preview of the output filter"
+      description: "Get a preview of up to 100 observations using the state of the filter output job. By default only 20 rows will be returned. To change this use the `limit` query. It could be possible no results are returned due to data sparsity."
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "A preview of the current filter state has been returned"
+          schema:
+            $ref: '#/definitions/Preview'
+        400:
+          description: "No dimensions are present in the filter blue print"
+        404:
+          description: "The filter id was not found"
         500:
           $ref: '#/responses/InternalError'
 responses:


### PR DESCRIPTION
### What

As a basic preview version the results are returned as two dimensional
array, the headers are seperated, columns and rows sizes are
shown.

### How to review

read the swagger spec

### Who can review

anyone
