### PR TITLE
The first neo4j connection is lost in the pool

### DIFF
--- a/cmd/dp-filter-api/main.go
+++ b/cmd/dp-filter-api/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	client := rchttp.DefaultClient
 	datasetAPI := dataset.NewDatasetAPI(client, cfg.DatasetAPIURL, cfg.DatasetAPIAuthToken)
-	pool.OpenPool()
+
 	observationStore := observation.NewStore(pool)
 	previewDatasets := preview.PreviewDatasetStore{Store: observationStore}
 	outputQueue := filterOutputQueue.CreateOutputQueue(producer.Output())


### PR DESCRIPTION
### What

The first neo4j connection in the pool is lost, as the connection is not used or closed.

### How to review

Review the code

### Who can review

anyone
