### PR TITLE
Allow events to be passed to the filter api

### DIFF
--- a/api/filters.go
+++ b/api/filters.go
@@ -556,7 +556,7 @@ func (api *FilterAPI) updateFilterOutput(w http.ResponseWriter, r *http.Request)
 func (api *FilterAPI) createFilterOutputResource(newFilter *models.Filter, filterBlueprintID string) models.Filter {
 	filterOutput := *newFilter
 	filterOutput.FilterID = uuid.NewV4().String()
-	filterOutput.State = "created"
+	filterOutput.State = models.CreatedState
 	filterOutput.Links.Self.HRef = fmt.Sprintf("%s/filter-outputs/%s", api.host, filterOutput.FilterID)
 	filterOutput.Links.Dimensions.HRef = ""
 	filterOutput.Links.FilterBlueprint.HRef = fmt.Sprintf("%s/filters/%s", api.host, filterBlueprintID)

--- a/models/models.go
+++ b/models/models.go
@@ -9,6 +9,12 @@ import (
 	"time"
 )
 
+const (
+	CreatedState   = "created"
+	SubmittedState = "submitted"
+	CompletedState = "completed"
+)
+
 // Filter represents a structure for a filter job
 type Filter struct {
 	InstanceID  string      `bson:"instance_id"          json:"instance_id"`

--- a/mongo/filterstore.go
+++ b/mongo/filterstore.go
@@ -11,12 +11,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-// Filter job states
-const (
-	submitted = "submitted"
-	completed = "completed"
-)
-
 // Error codes
 var (
 	errNotAuthorised = errors.New("Not authorised")
@@ -422,7 +416,7 @@ func createUpdateFilterBlueprint(filter *models.Filter, currentTime time.Time) b
 func createUpdateFilterOutput(filter *models.Filter, currentTime time.Time) bson.M {
 
 	var downloads models.Downloads
-	state := "created"
+	state := models.CreatedState
 	var update bson.M
 	if filter.Downloads != nil {
 		if filter.Downloads.XLS.URL != "" {
@@ -448,7 +442,7 @@ func createUpdateFilterOutput(filter *models.Filter, currentTime time.Time) bson
 			"$set": bson.M{
 				"downloads": downloads,
 				"events":    filter.Events,
-				"state":     completed,
+				"state":     models.CompletedState,
 			},
 			"$setOnInsert": bson.M{
 				"last_updated": currentTime,
@@ -476,7 +470,7 @@ func (s *FilterStore) checkFilterState(filterID string) error {
 		return err
 	}
 
-	if filter.State == submitted {
+	if filter.State == models.SubmittedState {
 		return errForbidden
 	}
 

--- a/mongo/filterstore.go
+++ b/mongo/filterstore.go
@@ -422,19 +422,24 @@ func createUpdateFilterBlueprint(filter *models.Filter, currentTime time.Time) b
 func createUpdateFilterOutput(filter *models.Filter, currentTime time.Time) bson.M {
 
 	var downloads models.Downloads
-
+	state := "created"
 	var update bson.M
+	if filter.Downloads != nil {
+		if filter.Downloads.XLS.URL != "" {
+			downloads.XLS = filter.Downloads.XLS
+		}
 
-	if filter.Downloads.XLS.URL != "" {
-		downloads.XLS = filter.Downloads.XLS
+		if filter.Downloads.CSV.URL != "" {
+			downloads.CSV = filter.Downloads.CSV
+		}
+
+		if filter.Downloads.JSON.URL != "" {
+			downloads.JSON = filter.Downloads.JSON
+		}
 	}
 
-	if filter.Downloads.CSV.URL != "" {
-		downloads.CSV = filter.Downloads.CSV
-	}
-
-	if filter.Downloads.JSON.URL != "" {
-		downloads.JSON = filter.Downloads.JSON
+	if filter.State != "" {
+		state = filter.State
 	}
 
 	// Don't bother checking for JSON as it doesn't get generated at the moment
@@ -452,6 +457,7 @@ func createUpdateFilterOutput(filter *models.Filter, currentTime time.Time) bson
 	} else {
 		update = bson.M{
 			"$set": bson.M{
+				"state":     state,
 				"downloads": downloads,
 				"events":    filter.Events,
 			},

--- a/mongo/filterstore_test.go
+++ b/mongo/filterstore_test.go
@@ -1,0 +1,91 @@
+package mongo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ONSdigital/dp-filter-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/mgo.v2/bson"
+)
+
+func TestCreateUpdateFilterOutput(t *testing.T) {
+	Convey("When a filter output is updated with a new CSV file", t, func() {
+		filterOutput := models.Filter{
+			Downloads: &models.Downloads{
+				CSV: models.DownloadItem{
+					URL:  "http://dataset-bucket/123.csv",
+					Size: "321",
+				},
+			},
+		}
+		data := createUpdateFilterOutput(&filterOutput, time.Now())
+		Convey("Then the returned bson object contains the latest changes", func() {
+			downloads := data["$set"].(bson.M)["downloads"].(models.Downloads)
+			So(downloads.CSV.URL, ShouldEndWith, filterOutput.Downloads.CSV.URL)
+			So(downloads.CSV.Size, ShouldEndWith, filterOutput.Downloads.CSV.Size)
+		})
+	})
+
+	Convey("When a filter output is updated with a new XLSX file", t, func() {
+		filterOutput := models.Filter{
+			Downloads: &models.Downloads{
+				XLS: models.DownloadItem{
+					URL:  "http://dataset-bucket/123.xlsx",
+					Size: "3213",
+				},
+			},
+		}
+		data := createUpdateFilterOutput(&filterOutput, time.Now())
+		Convey("Then the returned bson object contains the latest changes", func() {
+			downloads := data["$set"].(bson.M)["downloads"].(models.Downloads)
+			So(downloads.XLS.URL, ShouldEndWith, filterOutput.Downloads.XLS.URL)
+			So(downloads.XLS.Size, ShouldEndWith, filterOutput.Downloads.XLS.Size)
+		})
+	})
+
+	Convey("When a filter output is updated with both a XLSX and CSV file", t, func() {
+		filterOutput := models.Filter{
+			Downloads: &models.Downloads{
+				XLS: models.DownloadItem{
+					URL:  "http://dataset-bucket/123.xlsx",
+					Size: "3213",
+				},
+				CSV: models.DownloadItem{
+					URL:  "http://dataset-bucket/123.csv",
+					Size: "321",
+				},
+			},
+		}
+		data := createUpdateFilterOutput(&filterOutput, time.Now())
+		Convey("Then the returned bson object contains the latest changes", func() {
+			state := data["$set"].(bson.M)["state"].(string)
+			downloads := data["$set"].(bson.M)["downloads"].(models.Downloads)
+			So(downloads.XLS.URL, ShouldEndWith, filterOutput.Downloads.XLS.URL)
+			So(downloads.XLS.Size, ShouldEndWith, filterOutput.Downloads.XLS.Size)
+			So(downloads.CSV.URL, ShouldEndWith, filterOutput.Downloads.CSV.URL)
+			So(downloads.CSV.Size, ShouldEndWith, filterOutput.Downloads.CSV.Size)
+			So(state, ShouldEqual, models.CompletedState)
+
+		})
+	})
+	Convey("When a filter output is updated with event and state", t, func() {
+		filterOutput := models.Filter{
+			State: models.CompletedState,
+			Events: models.Events{
+				Info: []models.EventItem{{
+					Message: "empty filter job",
+					Time:    time.Now().UTC().String(),
+				}},
+			},
+		}
+		data := createUpdateFilterOutput(&filterOutput, time.Now())
+		Convey("Then the returned bson object contains the latest changes", func() {
+			state := data["$set"].(bson.M)["state"].(string)
+			event := data["$set"].(bson.M)["events"].(models.Events)
+			So(len(event.Info), ShouldEqual, 1)
+			So(state, ShouldEqual, models.CompletedState)
+
+		})
+	})
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -440,9 +440,10 @@ definitions:
           The state of the job can be in five states;
           * created - The job is ready to be updated with filters. (default state)
           * submitted - The job has been submitted to be processed. This will lock the job and no further changes can be done
-          * in progress -
-          * completed - The job has been completed and can be downloaded using the `downloadUrl`
-          * failed - The job failed to be processed
+          * completed - The job has been completed, if the filter created results the download links will contain links. It is
+                        possible that a job gets marked as completed but no download URLs are present, this is due to the filter job
+                        returning no results. See the information events for more information.
+          * failed - The job failed to be processed, See error events for more information
       downloads:
         $ref: '#/definitions/Downloads'
       events:


### PR DESCRIPTION
### What
The filter-api already supported this but there was a bug
which needed to be addressed before events could be added
to a filter output.

Added more information in the swagger spec about completed and
failed jobs.

### How to review
review code and swagger spec

### Who can review
anyone
