### PR TITLE
Move away from using the instance id and to fetch datasets

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -533,7 +533,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 	})
 
 	Convey("When a json message is sent to change the datset version of a filter blueprint and the current dimensions do not match, a status of bad request is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1}}`)
+		reader := strings.NewReader(`{"dataset":{"version":2}}`)
 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
 		So(err, ShouldBeNil)
 
@@ -548,7 +548,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 	})
 
 	Convey("When a json message is sent to change the dataset version of a filter blueprint and the current dimension options do not match, a status of bad request is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1}}`)
+		reader := strings.NewReader(`{"dataset":{"version":2}}`)
 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
 		So(err, ShouldBeNil)
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ONSdigital/go-ns/rchttp"
 	"github.com/gorilla/mux"
 
 	"github.com/ONSdigital/dp-filter-api/api/datastoretest"
@@ -21,7 +20,6 @@ import (
 var (
 	host       = "http://localhost:80"
 	authHeader = "cake"
-	client     = rchttp.DefaultClient
 )
 
 var previewMock = &datastoretest.PreviewDatasetMock{
@@ -33,7 +31,7 @@ var previewMock = &datastoretest.PreviewDatasetMock{
 func TestSuccessfulAddFilterBlueprint(t *testing.T) {
 	t.Parallel()
 	Convey("Successfully create a filter blueprint", t, func() {
-		reader := strings.NewReader(`{"instance_id":"12345678"}`)
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "dataset_id":"1"} }`)
 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
 		So(err, ShouldBeNil)
 
@@ -44,7 +42,7 @@ func TestSuccessfulAddFilterBlueprint(t *testing.T) {
 	})
 
 	Convey("Successfully create a filter blueprint with dimensions", t, func() {
-		reader := strings.NewReader(`{"instance_id":"12345678", "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "dataset_id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
 		So(err, ShouldBeNil)
 
@@ -56,7 +54,7 @@ func TestSuccessfulAddFilterBlueprint(t *testing.T) {
 
 	//	TODO check test doesn't actually write job to queue?
 	Convey("Successfully submit a filter blueprint", t, func() {
-		reader := strings.NewReader(`{"instance_id":"12345678"}`)
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "dataset_id":"1"} }`)
 		r, err := http.NewRequest("POST", "http://localhost:22100/filters?submitted=true", reader)
 		So(err, ShouldBeNil)
 
@@ -70,7 +68,7 @@ func TestSuccessfulAddFilterBlueprint(t *testing.T) {
 func TestFailedToAddFilterBlueprint(t *testing.T) {
 	t.Parallel()
 	Convey("When no data store is available, an internal error is returned", t, func() {
-		reader := strings.NewReader(`{"instance_id":"12345678"}`)
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "dataset_id":"1"} }`)
 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
 		So(err, ShouldBeNil)
 
@@ -85,7 +83,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 	})
 
 	Convey("When dataset API is unavailable, an internal error is returned", t, func() {
-		reader := strings.NewReader(`{"instance_id":"12345678"}`)
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "dataset_id":"1"} }`)
 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
 		So(err, ShouldBeNil)
 
@@ -100,7 +98,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 	})
 
 	Convey("When instance does not exist, a not found error is returned", t, func() {
-		reader := strings.NewReader(`{"instance_id":"12345678"}`)
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "dataset_id":"1"} }`)
 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
 		So(err, ShouldBeNil)
 
@@ -160,7 +158,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 	})
 
 	Convey("When a json message contains a dimension that does not exist, a bad request is returned", t, func() {
-		reader := strings.NewReader(`{"instance_id":"12345678", "dimensions":[{"name": "weight", "options": ["27","33"]}]}`)
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "dataset_id":"1"} , "dimensions":[{"name": "weight", "options": ["27","33"]}]}`)
 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
 		So(err, ShouldBeNil)
 
@@ -175,7 +173,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 	})
 
 	Convey("When a json message contains a dimension option that does not exist for a valid dimension, a bad request is returned", t, func() {
-		reader := strings.NewReader(`{"instance_id":"12345678", "dimensions":[{"name": "age", "options": ["29","33"]}]}`)
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "dataset_id":"1"} , "dimensions":[{"name": "age", "options": ["29","33"]}]}`)
 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
 		So(err, ShouldBeNil)
 
@@ -419,7 +417,7 @@ func TestFailedToGetFilterBlueprint(t *testing.T) {
 func TestSuccessfulUpdateFilterBlueprint(t *testing.T) {
 	t.Parallel()
 	Convey("Successfully send a valid json message", t, func() {
-		reader := strings.NewReader(`{"instance_id":"123"}`)
+		reader := strings.NewReader(`{"state":"created"}`)
 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
 		So(err, ShouldBeNil)
 
@@ -500,7 +498,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 
 		bodyBytes, _ := ioutil.ReadAll(w.Body)
 		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad request - instance not found\n")
+		So(response, ShouldResemble, "Bad request - version not found\n")
 	})
 
 	Convey("When a json message is sent to change the instance id of a filter blueprint and the current dimensions do not match, a status of bad request is returned", t, func() {

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -188,6 +188,7 @@ func (api *DatasetAPI) callDatasetAPI(ctx context.Context, method, path string, 
 			log.ErrorC("error cleaning up request body", err, logData)
 		}
 	}()
+	logData["httpCode"] = resp.StatusCode
 
 	jsonBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -195,7 +196,6 @@ func (api *DatasetAPI) callDatasetAPI(ctx context.Context, method, path string, 
 		return nil, resp.StatusCode, err
 	}
 
-	logData["httpCode"] = resp.StatusCode
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= 300 {
 		return jsonBody, resp.StatusCode, ErrUnexpectedStatusCode
 	}

--- a/mocks/datasetapi.go
+++ b/mocks/datasetapi.go
@@ -23,7 +23,7 @@ var (
 )
 
 // GetInstance represents the mocked version of getting an instance document from dataset API
-func (ds *DatasetAPI) GetInstance(ctx context.Context, id string) (*models.Instance, error) {
+func (ds *DatasetAPI) GetVersion(ctx context.Context, dataset models.Dataset) (*models.Version, error) {
 	if ds.InternalServerError {
 		return nil, errorInternalServer
 	}
@@ -32,8 +32,8 @@ func (ds *DatasetAPI) GetInstance(ctx context.Context, id string) (*models.Insta
 		return nil, errorInstanceNotFound
 	}
 
-	return &models.Instance{
-		Links: models.InstanceLinks{
+	return &models.Version{
+		Links: models.VersionLinks{
 			Dataset: models.LinkObject{
 				ID: "123",
 			},
@@ -48,7 +48,7 @@ func (ds *DatasetAPI) GetInstance(ctx context.Context, id string) (*models.Insta
 }
 
 // GetVersionDimensions represents the mocked version of getting a list of dimensions from the dataset API
-func (ds *DatasetAPI) GetVersionDimensions(ctx context.Context, datasetID, edition, version string) (*models.DatasetDimensionResults, error) {
+func (ds *DatasetAPI) GetVersionDimensions(ctx context.Context, dataset models.Dataset) (*models.DatasetDimensionResults, error) {
 	if ds.InternalServerError {
 		return nil, errorInternalServer
 	}
@@ -67,7 +67,7 @@ func (ds *DatasetAPI) GetVersionDimensions(ctx context.Context, datasetID, editi
 }
 
 // GetVersionDimensionOptions represents the mocked version of getting a list of dimension options from the dataset API
-func (ds *DatasetAPI) GetVersionDimensionOptions(ctx context.Context, datasetID, edition, version, dimension string) (*models.DatasetDimensionOptionResults, error) {
+func (ds *DatasetAPI) GetVersionDimensionOptions(ctx context.Context, dataset models.Dataset, dimension string) (*models.DatasetDimensionOptionResults, error) {
 	if ds.InternalServerError {
 		return nil, errorInternalServer
 	}

--- a/mocks/datasetapi.go
+++ b/mocks/datasetapi.go
@@ -11,25 +11,25 @@ import (
 type DatasetAPI struct {
 	DimensionsNotFound       bool
 	DimensionOptionsNotFound bool
-	InstanceNotFound         bool
+	VersionNotFound          bool
 	InternalServerError      bool
 }
 
 // A list of errors that can be returned by the mock package
 var (
-	errorInstanceNotFound         = errors.New("Instance not found")
+	errorVersionNotFound          = errors.New("Version not found")
 	errorDimensionsNotFound       = errors.New("Dimensions not found")
 	errorDimensionOptionsNotFound = errors.New("Dimension options not found")
 )
 
-// GetInstance represents the mocked version of getting an instance document from dataset API
+// GetVersion represents the mocked version of getting an version document from dataset API
 func (ds *DatasetAPI) GetVersion(ctx context.Context, dataset models.Dataset) (*models.Version, error) {
 	if ds.InternalServerError {
 		return nil, errorInternalServer
 	}
 
-	if ds.InstanceNotFound {
-		return nil, errorInstanceNotFound
+	if ds.VersionNotFound {
+		return nil, errorVersionNotFound
 	}
 
 	return &models.Version{

--- a/mocks/datastore.go
+++ b/mocks/datastore.go
@@ -101,18 +101,18 @@ func (ds *DataStore) GetFilter(filterID string) (*models.Filter, error) {
 	}
 
 	if ds.BadRequest {
-		return &models.Filter{InstanceID: "12345678"}, nil
+		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678"}, errorBadRequest
 	}
 
 	if ds.ChangeInstanceRequest {
-		return &models.Filter{InstanceID: "12345678", Dimensions: []models.Dimension{{Name: "age", Options: []string{"33"}}}}, nil
+		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Dimensions: []models.Dimension{{Name: "age", Options: []string{"33"}}}}, nil
 	}
 
 	if ds.InvalidDimensionOption {
-		return &models.Filter{InstanceID: "12345678", Dimensions: []models.Dimension{{Name: "age", Options: []string{"28"}}}}, nil
+		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Dimensions: []models.Dimension{{Name: "age", Options: []string{"28"}}}}, nil
 	}
 
-	return &models.Filter{InstanceID: "12345678", Dimensions: []models.Dimension{{Name: "time"}}}, nil
+	return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Dimensions: []models.Dimension{{Name: "time"}}}, nil
 }
 
 // GetFilterDimensions represents the mocked version of getting a list of filter dimensions from the datastore

--- a/mocks/datastore.go
+++ b/mocks/datastore.go
@@ -23,7 +23,7 @@ type DataStore struct {
 	NotFound               bool
 	DimensionNotFound      bool
 	OptionNotFound         bool
-	InstanceNotFound       bool
+	VersionNotFound        bool
 	BadRequest             bool
 	Forbidden              bool
 	Unauthorised           bool
@@ -267,8 +267,8 @@ func (ds *DataStore) UpdateFilter(filterJob *models.Filter) error {
 		return errorFilterOutputNotFound
 	}
 
-	if ds.InstanceNotFound {
-		return errorInstanceNotFound
+	if ds.VersionNotFound {
+		return errorVersionNotFound
 	}
 	return nil
 }

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -19,35 +19,26 @@ func (f reader) Read(bytes []byte) (int, error) {
 
 func TestCreateFilterBlueprintWithValidJSON(t *testing.T) {
 	Convey("When a filter blueprint has a valid json body, a message is returned", t, func() {
-		reader := strings.NewReader(`{"instance_id":"12345678"}`)
-		filter, err := CreateFilter(reader)
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "dataset_id":"1"} }`)
+		filter, err := CreateNewFilter(reader)
 		So(err, ShouldBeNil)
-		So(filter.ValidateFilterBlueprint(), ShouldBeNil)
-		So(filter.FilterID, ShouldNotBeNil)
-		So(filter.InstanceID, ShouldEqual, "12345678")
-		So(filter.State, ShouldEqual, "")
-	})
-
-	Convey("When a filter blueprint has a valid json body with a state, a message is returned", t, func() {
-		reader := strings.NewReader(`{"instance_id":"12345678","state":"created"}`)
-		filter, err := CreateFilter(reader)
-		So(err, ShouldBeNil)
-		So(filter.ValidateFilterBlueprint(), ShouldBeNil)
-		So(filter.FilterID, ShouldNotBeNil)
-		So(filter.InstanceID, ShouldEqual, "12345678")
-		So(filter.State, ShouldEqual, "")
+		So(filter.ValidateNewFilter(), ShouldBeNil)
+		So(filter.Dataset, ShouldNotBeNil)
+		So(filter.Dataset.DatasetId, ShouldEqual, "1")
+		So(filter.Dataset.Edition, ShouldEqual, "1")
+		So(filter.Dataset.Version, ShouldEqual, 1)
 	})
 }
 
 func TestCreateFilterWithNoBody(t *testing.T) {
 	Convey("When a filter message has no body, an error is returned", t, func() {
-		_, err := CreateFilter(reader{})
+		_, err := CreateNewFilter(reader{})
 		So(err, ShouldNotBeNil)
 		So(err, ShouldEqual, ErrorReadingBody)
 	})
 
 	Convey("When a filter message has an empty body, an error is returned", t, func() {
-		filter, err := CreateFilter(strings.NewReader("{}"))
+		filter, err := CreateNewFilter(strings.NewReader("{}"))
 		So(err, ShouldNotBeNil)
 		So(err, ShouldResemble, ErrorNoData)
 		So(filter, ShouldNotBeNil)
@@ -55,22 +46,22 @@ func TestCreateFilterWithNoBody(t *testing.T) {
 }
 
 func TestCreateFilterBlueprintWithInvalidJson(t *testing.T) {
-	Convey("When a filter blueprint message is missing instance_id field, an error is returned", t, func() {
-		filter, err := CreateFilter(strings.NewReader(`{"state":"created"}`))
+	Convey("When a filter blueprint message is missing dataset fields, an error is returned", t, func() {
+		filter, err := CreateNewFilter(strings.NewReader(`{"dataset":{"version":1} }`))
 		So(err, ShouldBeNil)
 
-		err = filter.ValidateFilterBlueprint()
-		missingFields := []string{"instance_id"}
+		err = filter.ValidateNewFilter()
+		missingFields := []string{"edition", "dataset_id"}
 		So(err, ShouldNotBeNil)
 		So(err, ShouldResemble, fmt.Errorf("Missing mandatory fields: %v", missingFields))
 	})
 
 	Convey("When a filter blueprint message has an empty json body, an error is returned", t, func() {
-		filter, err := CreateFilter(strings.NewReader("{ }"))
+		filter, err := CreateNewFilter(strings.NewReader("{ }"))
 		So(err, ShouldBeNil)
 
-		err = filter.ValidateFilterBlueprint()
-		missingFields := []string{"instance_id"}
+		err = filter.ValidateNewFilter()
+		missingFields := []string{"version", "edition", "dataset_id"}
 		So(err, ShouldNotBeNil)
 		So(err, ShouldResemble, fmt.Errorf("Missing mandatory fields: %v", missingFields))
 	})

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -51,7 +51,7 @@ func TestCreateFilterBlueprintWithInvalidJson(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		err = filter.ValidateNewFilter()
-		missingFields := []string{"edition", "id"}
+		missingFields := []string{"dataset.edition", "dataset.id"}
 		So(err, ShouldNotBeNil)
 		So(err, ShouldResemble, fmt.Errorf("Missing mandatory fields: %v", missingFields))
 	})
@@ -61,7 +61,7 @@ func TestCreateFilterBlueprintWithInvalidJson(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		err = filter.ValidateNewFilter()
-		missingFields := []string{"version", "edition", "id"}
+		missingFields := []string{"dataset.version", "dataset.edition", "dataset.id"}
 		So(err, ShouldNotBeNil)
 		So(err, ShouldResemble, fmt.Errorf("Missing mandatory fields: %v", missingFields))
 	})

--- a/models/version.go
+++ b/models/version.go
@@ -1,13 +1,15 @@
 package models
 
 // Instance represents the json returned from the dataset API for an instance document
-type Instance struct {
-	Links InstanceLinks `json:"links,omitempty"`
-	State string        `json:"state,omitempty"`
+type Version struct {
+	ID      string       `json:"id,omitempty"`
+	Links   VersionLinks `json:"links,omitempty"`
+	State   string       `json:"state,omitempty"`
+	Version int          `json:"version,omitempty"`
 }
 
 // InstanceLinks represents a list of link objects related to the instance resource
-type InstanceLinks struct {
+type VersionLinks struct {
 	Dataset LinkObject `bson:"dataset,omitempty" json:"dataset"`
 	Edition LinkObject `bson:"edition,omitempty" json:"edition"`
 	Self    LinkObject `bson:"self,omitempty"    json:"self"`

--- a/models/version.go
+++ b/models/version.go
@@ -1,6 +1,6 @@
 package models
 
-// Instance represents the json returned from the dataset API for an instance document
+// Version represents the json returned from the dataset API for a version resource
 type Version struct {
 	ID      string       `json:"id,omitempty"`
 	Links   VersionLinks `json:"links,omitempty"`
@@ -8,7 +8,7 @@ type Version struct {
 	Version int          `json:"version,omitempty"`
 }
 
-// InstanceLinks represents a list of link objects related to the instance resource
+// VersionLinks represents a list of link objects related to the version resource
 type VersionLinks struct {
 	Dataset LinkObject `bson:"dataset,omitempty" json:"dataset"`
 	Edition LinkObject `bson:"edition,omitempty" json:"edition"`

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -382,10 +382,11 @@ definitions:
   NewBlueprintRequest:
     description: "A model used to create new filter blueprints. Dimensions are optional"
     allOf:
-    - $ref: '#/definitions/Dataset'
     - $ref: '#/definitions/JobState'
     - type: object
       properties:
+        dataset:
+          $ref: '#/definitions/Dataset'
         dimensions:
           readOnly: false
           type: array
@@ -398,6 +399,14 @@ definitions:
     - $ref: '#/definitions/JobState'
     - type: object
       properties:
+        dataset:
+          readOnly: false
+          type: object
+          description: 'A dataset to filter on'
+          properties:
+            version:
+              type: integer
+              description: "A version of the dataset to filter on"
         events:
           readOnly: false
           type: object
@@ -410,12 +419,17 @@ definitions:
     allOf:
     - $ref: '#/definitions/JobState'
     - type: object
+      properties:
+        dataset:
+          $ref: '#/definitions/Dataset'
   UpdateBlueprintResponse:
     description: "A model for the response body when updating a filter blueprint"
     allOf:
     - $ref: '#/definitions/JobState'
     - type: object
       properties:
+        dataset:
+          $ref: '#/definitions/Dataset'
         links:
           type: object
           properties:
@@ -468,11 +482,13 @@ definitions:
       events:
         $ref: '#/definitions/Events'
   Dataset:
+    readOnly: false
     type: object
+    description: "A version of an edition for a dataset to filter on."
     properties:
-      dataset_id:
+      id:
         type: string
-        description: "An unique dataset id"
+        description: "The unique identifier of a dataset"
       edition:
         type: string
         description: "An edition of a dataset"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -382,6 +382,7 @@ definitions:
   NewBlueprintRequest:
     description: "A model used to create new filter blueprints. Dimensions are optional"
     allOf:
+    - $ref: '#/definitions/Dataset'
     - $ref: '#/definitions/JobState'
     - type: object
       properties:
@@ -458,9 +459,6 @@ definitions:
         readOnly: true
         type: string
         description: "A unique id for this resource"
-      instance_id:
-        type: string
-        description: 'An instance ID for he specific dataset version to be filtered'
       dimension_list_url:
         readOnly: true
         type: string
@@ -469,6 +467,18 @@ definitions:
         $ref: '#/definitions/FilterLinks'
       events:
         $ref: '#/definitions/Events'
+  Dataset:
+    type: object
+    properties:
+      dataset_id:
+        type: string
+        description: "An unique dataset id"
+      edition:
+        type: string
+        description: "An edition of a dataset"
+      version:
+        type: string
+        description: "A version of a dataset"
   Dimension:
     type: object
     description: "A dimension to filter on a dataset. Information on a dimension can be gathered using the `Dataset API`"


### PR DESCRIPTION
### What

Use dataset_id, edition and version to create a filter job. This change is needed as the filter api can no longer call the instance endpoints on the dataset api

### How to review

review the code, run the unit tests. 

### Who can review

Anyone
