### PR TITLE
Update downloads object to contain public and private links

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -33,12 +33,13 @@ type PreviewDataset interface {
 
 // FilterAPI manages importing filters against a dataset
 type FilterAPI struct {
-	host        string
-	dataStore   DataStore
-	outputQueue OutputQueue
-	router      *mux.Router
-	datasetAPI  DatasetAPIer
-	preview     PreviewDataset
+	host               string
+	dataStore          DataStore
+	outputQueue        OutputQueue
+	router             *mux.Router
+	datasetAPI         DatasetAPIer
+	preview            PreviewDataset
+	downloadServiceURL string
 }
 
 // CreateFilterAPI manages all the routes configured to API
@@ -48,10 +49,11 @@ func CreateFilterAPI(host, bindAddr, zebedeeURL string,
 	errorChan chan error,
 	datasetAPI DatasetAPIer,
 	preview PreviewDataset,
-	enablePrivateEndpoints bool) {
+	enablePrivateEndpoints bool,
+	downloadServiceURL string) {
 
 	router := mux.NewRouter()
-	routes(host, router, datastore, outputQueue, datasetAPI, preview, enablePrivateEndpoints)
+	routes(host, router, datastore, outputQueue, datasetAPI, preview, enablePrivateEndpoints, downloadServiceURL)
 
 	// Only add the identity middleware when running in publishing.
 	if enablePrivateEndpoints {
@@ -81,9 +83,17 @@ func routes(host string,
 	outputQueue OutputQueue,
 	datasetAPI DatasetAPIer,
 	preview PreviewDataset,
-	enablePrivateEndpoints bool) *FilterAPI {
+	enablePrivateEndpoints bool,
+	downloadServiceURL string) *FilterAPI {
 
-	api := FilterAPI{host: host, dataStore: dataStore, router: router, outputQueue: outputQueue, datasetAPI: datasetAPI, preview: preview}
+	api := FilterAPI{host: host,
+		dataStore: dataStore,
+		router: router,
+		outputQueue: outputQueue,
+		datasetAPI: datasetAPI,
+		preview: preview,
+		downloadServiceURL: downloadServiceURL}
+
 	router.Path("/healthcheck").Methods("GET").HandlerFunc(healthcheck.Do)
 
 	api.router.HandleFunc("/filters", api.addFilterBlueprint).Methods("POST")

--- a/api/api.go
+++ b/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+
 	"github.com/ONSdigital/dp-filter-api/models"
 	"github.com/ONSdigital/dp-filter-api/preview"
 	"github.com/ONSdigital/go-ns/healthcheck"

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -23,6 +23,7 @@ import (
 const (
 	host                   = "http://localhost:80"
 	enablePrivateEndpoints = true
+	downloadServiceURL = "http://localhost:23600"
 )
 
 var previewMock = &datastoretest.PreviewDatasetMock{
@@ -39,7 +40,7 @@ func TestSuccessfulAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -49,7 +50,7 @@ func TestSuccessfulAddFilterBlueprint(t *testing.T) {
 		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -60,7 +61,7 @@ func TestSuccessfulAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -72,7 +73,7 @@ func TestSuccessfulAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -86,7 +87,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -100,7 +101,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{InternalServerError: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{InternalServerError: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -114,7 +115,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -128,7 +129,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -142,7 +143,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -156,7 +157,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -170,7 +171,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -184,7 +185,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -198,7 +199,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -215,7 +216,7 @@ func TestSuccessfulAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -226,7 +227,7 @@ func TestSuccessfulAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -237,7 +238,7 @@ func TestSuccessfulAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -247,7 +248,7 @@ func TestSuccessfulAddFilterBlueprintDimension(t *testing.T) {
 		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -261,7 +262,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -275,7 +276,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -289,7 +290,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -303,7 +304,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -317,7 +318,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -331,7 +332,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -347,7 +348,7 @@ func TestSuccessfulAddFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -356,7 +357,7 @@ func TestSuccessfulAddFilterBlueprintDimensionOption(t *testing.T) {
 		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -369,7 +370,7 @@ func TestFailedToAddFilterBlueprintDimensionOption_DimensionDoesNotExist(t *test
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -385,7 +386,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -398,7 +399,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -411,7 +412,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -424,7 +425,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -440,7 +441,7 @@ func TestSuccessfulGetFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -450,7 +451,7 @@ func TestSuccessfulGetFilterBlueprint(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678", nil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -464,7 +465,7 @@ func TestFailedToGetFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -478,7 +479,7 @@ func TestFailedToGetFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -491,7 +492,7 @@ func TestFailedToGetFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -508,7 +509,7 @@ func TestSuccessfulUpdateFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -524,7 +525,7 @@ func TestSuccessfulUpdateFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -535,7 +536,7 @@ func TestSuccessfulUpdateFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -545,7 +546,7 @@ func TestSuccessfulUpdateFilterBlueprint(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filters/21312?submitted=true", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -559,7 +560,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -573,7 +574,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -587,7 +588,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -602,7 +603,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 
 		w := httptest.NewRecorder()
 
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -616,7 +617,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -630,7 +631,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -644,7 +645,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -660,7 +661,7 @@ func TestSuccessfulGetFilterBlueprintDimensions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -669,7 +670,7 @@ func TestSuccessfulGetFilterBlueprintDimensions(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -682,7 +683,7 @@ func TestFailedToGetFilterBlueprintDimensions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -695,7 +696,7 @@ func TestFailedToGetFilterBlueprintDimensions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -711,7 +712,7 @@ func TestSuccessfulGetFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 	})
@@ -720,7 +721,7 @@ func TestSuccessfulGetFilterBlueprintDimension(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 	})
@@ -733,7 +734,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -746,7 +747,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -759,7 +760,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -772,7 +773,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -788,7 +789,7 @@ func TestSuccessfulGetFilterBlueprintDimensionOptions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -797,7 +798,7 @@ func TestSuccessfulGetFilterBlueprintDimensionOptions(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options", nil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -810,7 +811,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -823,7 +824,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -836,7 +837,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -849,7 +850,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -865,7 +866,7 @@ func TestSuccessfulGetFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 	})
@@ -874,7 +875,7 @@ func TestSuccessfulGetFilterBlueprintDimensionOption(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 	})
@@ -887,7 +888,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -900,7 +901,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -913,7 +914,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -926,7 +927,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -942,7 +943,7 @@ func TestSuccessfulRemoveFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -951,7 +952,7 @@ func TestSuccessfulRemoveFilterBlueprintDimension(t *testing.T) {
 		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -964,7 +965,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -977,7 +978,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -990,7 +991,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -1003,7 +1004,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -1019,7 +1020,7 @@ func TestSuccessfulRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -1028,7 +1029,7 @@ func TestSuccessfulRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -1041,7 +1042,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -1054,7 +1055,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -1067,7 +1068,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -1080,7 +1081,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -1096,7 +1097,7 @@ func TestSuccessfulGetFilterOutput(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -1117,7 +1118,7 @@ func TestSuccessfulGetFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -1138,7 +1139,7 @@ func TestSuccessfulGetFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -1152,7 +1153,7 @@ func TestFailedToGetFilterOutput(t *testing.T) {
 
 		w := httptest.NewRecorder()
 
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -1165,7 +1166,7 @@ func TestFailedToGetFilterOutput(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -1178,7 +1179,7 @@ func TestFailedToGetFilterOutput(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -1191,21 +1192,21 @@ func TestSuccessfulUpdateFilterOutput(t *testing.T) {
 	t.Parallel()
 
 	Convey("Successfully update filter output when public csv download link is missing", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+		reader := strings.NewReader(`{"downloads":{"csv":{"size":"12mb", "public":"s3-public-csv-location"}}}`)
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
 
 	Convey("Successfully update filter output when public xls download link is missing", t, func() {
-		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-xls-location","size":"12mb", "public":"s3-public-xls-location"}}}`)
+		reader := strings.NewReader(`{"downloads":{"xls":{"size":"12mb", "public":"s3-public-xls-location"}}}`)
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -1216,21 +1217,21 @@ func TestSuccessfulUpdateFilterOutputUnpublished(t *testing.T) {
 	t.Parallel()
 
 	Convey("Successfully update filter output with private csv download link when version is unpublished", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "private": "s3-private-csv-location"}}}`)
+		reader := strings.NewReader(`{"downloads":{"csv":{"size":"12mb", "private": "s3-private-csv-location"}}}`)
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
 
 	Convey("Successfully update filter output with private xls download link when version is unpublished", t, func() {
-		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-csv-location","size":"12mb", "private":"s3-private-xls-location"}}}`)
+		reader := strings.NewReader(`{"downloads":{"xls":{"size":"12mb", "private":"s3-private-xls-location"}}}`)
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -1239,11 +1240,11 @@ func TestSuccessfulUpdateFilterOutputUnpublished(t *testing.T) {
 func TestFailedToUpdateFilterOutput(t *testing.T) {
 	t.Parallel()
 	Convey("When no data store is available, an internal error is returned", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+		reader := strings.NewReader(`{"downloads":{"csv":{"size":"12mb", "public":"s3-public-csv-location"}}}`)
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -1256,7 +1257,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -1265,11 +1266,11 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 	})
 
 	Convey("When an update to a filter output resource that does not exist, a not found is returned", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+		reader := strings.NewReader(`{"downloads":{"csv":{"size":"12mb", "public":"s3-public-csv-location"}}}`)
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 	})
@@ -1279,7 +1280,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -1292,7 +1293,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
@@ -1301,12 +1302,12 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 	})
 
 	Convey("When a json message is sent to change a filter output with the wrong authorisation header, an unauthorised status is returned", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+		reader := strings.NewReader(`{"downloads":{"csv":{"size":"12mb", "public":"s3-public-csv-location"}}}`)
 		r, err := http.NewRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -1315,11 +1316,11 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 	})
 
 	Convey("When a json message contains downloads object but current filter ouput has public csv download links already and version is published, than a forbidden status is returned", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+		reader := strings.NewReader(`{"downloads":{"csv":{"size":"12mb", "public":"s3-public-csv-location"}}}`)
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
@@ -1332,7 +1333,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
@@ -1341,11 +1342,11 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 	})
 
 	Convey("When a json message contains private csv link but current filter ouput has private csv download links already and version is published, than a forbidden status is returned", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "private":"s3-private-csv-location"}}}`)
+		reader := strings.NewReader(`{"downloads":{"csv":{"size":"12mb", "private":"s3-private-csv-location"}}}`)
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
@@ -1354,11 +1355,11 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 	})
 
 	Convey("When a json message contains private xls link but current filter ouput has private xls download links already and version is published, than a forbidden status is returned", t, func() {
-		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-xls-location","size":"12mb", "private":"s3-private-xls-location"}}}`)
+		reader := strings.NewReader(`{"downloads":{"xls":{"size":"12mb", "private":"s3-private-xls-location"}}}`)
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
@@ -1374,7 +1375,7 @@ func TestUpdateFilterOutput_PrivateEndpointsNotEnabled(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, false)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, false, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusMethodNotAllowed)
 	})
@@ -1387,7 +1388,7 @@ func TestSuccessfulGetPreview(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(previewMock.GetPreviewCalls()[0].Limit, ShouldEqual, 20)
@@ -1397,7 +1398,7 @@ func TestSuccessfulGetPreview(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(previewMock.GetPreviewCalls()[0].Limit, ShouldEqual, 20)
@@ -1413,7 +1414,7 @@ func TestSuccessfulGetPreview(t *testing.T) {
 				return &preview.FilterPreview{}, nil
 			},
 		}
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockForLimit, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockForLimit, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(previewMockForLimit.GetPreviewCalls()[0].Limit, ShouldEqual, 10)
@@ -1427,7 +1428,7 @@ func TestFailedGetPreview(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -1440,7 +1441,7 @@ func TestFailedGetPreview(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -1458,7 +1459,7 @@ func TestFailedGetPreview(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockInternalError, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockInternalError, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -1471,7 +1472,7 @@ func TestFailedGetPreview(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -1484,7 +1485,7 @@ func TestFailedGetPreview(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -1497,7 +1498,7 @@ func TestFailedGetPreview(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints)
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,22 +1,21 @@
 package api
 
 import (
-	"errors"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
-	"time"
+
+	"io"
 
 	"github.com/ONSdigital/dp-filter-api/api/datastoretest"
 	"github.com/ONSdigital/dp-filter-api/mocks"
 	"github.com/ONSdigital/dp-filter-api/models"
 	"github.com/ONSdigital/dp-filter-api/preview"
+	"github.com/ONSdigital/go-ns/identity"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
-	"io"
-	"github.com/ONSdigital/go-ns/identity"
 )
 
 var (
@@ -29,1119 +28,1119 @@ var previewMock = &datastoretest.PreviewDatasetMock{
 	},
 }
 
-func TestSuccessfulAddFilterBlueprint(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully create a filter blueprint", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusCreated)
-	})
-
-	Convey("Successfully create a filter blueprint for an unpublished version", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
-		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters", reader)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusCreated)
-	})
-
-	Convey("Successfully create a filter blueprint with dimensions", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusCreated)
-	})
-
-	//	TODO check test doesn't actually write job to queue?
-	Convey("Successfully submit a filter blueprint", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters?submitted=true", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusCreated)
-	})
-}
-
-func TestFailedToAddFilterBlueprint(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When dataset API is unavailable, an internal error is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{InternalServerError: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When version does not exist, a not found error is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Version not found\n")
-	})
-
-	Convey("When version is unpublished and the request is not authenticated, a bad request error is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, badRequest+"\n")
-	})
-
-	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
-		reader := strings.NewReader("{")
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, badRequest+"\n")
-	})
-
-	Convey("When a empty json message is sent, a bad request is returned", t, func() {
-		reader := strings.NewReader("{}")
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, badRequest+"\n")
-	})
-
-	Convey("When a json message is missing mandatory fields, a bad request is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":"Census"}`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, badRequest+"\n")
-	})
-
-	Convey("When a json message contains a dimension that does not exist, a bad request is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} , "dimensions":[{"name": "weight", "options": ["27","33"]}]}`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [weight]\n")
-	})
-
-	Convey("When a json message contains a dimension option that does not exist for a valid dimension, a bad request is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} , "dimensions":[{"name": "age", "options": ["29","33"]}]}`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [29]\n")
-	})
-}
-
-func TestSuccessfulAddFilterBlueprintDimension(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully create a dimension with an empty request body", t, func() {
-		reader := strings.NewReader("")
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusCreated)
-	})
-
-	Convey("Successfully create a dimension with a request body but no options", t, func() {
-		reader := strings.NewReader("{}")
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusCreated)
-	})
-
-	Convey("Successfully create a dimension with options", t, func() {
-		reader := strings.NewReader(`{"options":["27","33"]}`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusCreated)
-	})
-
-	Convey("Successfully create a dimension with options for an unpublished filter", t, func() {
-		reader := strings.NewReader(`{"options":["27","33"]}`)
-		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusCreated)
-	})
-}
-
-func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		reader := strings.NewReader(`{"options":["22","17"]}`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
-		reader := strings.NewReader("{")
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, badRequest+"\n")
-	})
-
-	Convey("When a filter blueprint does not exist, a not found is returned", t, func() {
-		reader := strings.NewReader(`{"options":["22","17"]}`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When an unpublished filter blueprint does not exist, and the request is not authenticated, a not found is returned", t, func() {
-		reader := strings.NewReader(`{"options":["22","17"]}`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When the dimension does not exist against the dataset filtered on, a bad request is returned", t, func() {
-		reader := strings.NewReader(`{"options":["22","17"]}`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/wealth", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [wealth]\n")
-	})
-
-	Convey("When a json body contains a dimension option that does not exist for a valid dimension, a bad request is returned", t, func() {
-		reader := strings.NewReader(`{"options":["22","33"]}`)
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [22]\n")
-	})
-}
-
-func TestSuccessfulAddFilterBlueprintDimensionOption(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully add a dimension option to a filter", t, func() {
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusCreated)
-	})
-
-	Convey("Successfully add a dimension option to an unpublished filter", t, func() {
-		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusCreated)
-	})
-}
-
-func TestFailedToAddFilterBlueprintDimensionOption_DimensionDoesNotExist(t *testing.T) {
-
-	Convey("When a dimension for filter blueprint does not exist, a bad request status is returned", t, func() {
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/notage/options/33", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [notage]\n")
-	})
-}
-
-func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When the filter blueprint does not exist, a bad request status is returned", t, func() {
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, statusBadRequest+"\n")
-	})
-
-	Convey("When the filter blueprint is unpublished, and the request is unauthenticated, a not found status is returned", t, func() {
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When the dimension option for filter blueprint does not exist, a bad request status is returned", t, func() {
-		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/66", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [66]\n")
-	})
-}
-
-func TestSuccessfulGetFilterBlueprint(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully get a published filter blueprint with no authentication", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-
-	Convey("Successfully get an unpublished filter blueprint with authentication", t, func() {
-		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678", nil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-}
-
-func TestFailedToGetFilterBlueprint(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When filter blueprint is unpublished, and the request is unauthenticated, a not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-}
-
-func TestSuccessfulUpdateFilterBlueprint(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully send a valid json message", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1}}`)
-		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-
-	Convey("Successfully send a valid json message with events and dataset version update", t, func() {
-
-		updateBlueprintData := `{"dataset":{"version":1}, "events":{"info":[{"time":"` + time.Now().String() +
-			`","type":"something changed","message":"something happened"}],"error":[{"time":"` + time.Now().String() +
-			`","type":"errored","message":"something errored"}]}}`
-
-		reader := strings.NewReader(updateBlueprintData)
-		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-
-	Convey("Successfully send a request to submit filter blueprint", t, func() {
-		reader := strings.NewReader("{}")
-		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312?submitted=true", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-
-	Convey("Successfully send a request to submit an unpublished filter blueprint", t, func() {
-		reader := strings.NewReader("{}")
-		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filters/21312?submitted=true", reader)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-}
-
-func TestFailedToUpdateFilterBlueprint(t *testing.T) {
-	t.Parallel()
-	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
-		reader := strings.NewReader("{")
-		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, badRequest+"\n")
-	})
-
-	Convey("When an empty json message is sent, a bad request is returned", t, func() {
-		reader := strings.NewReader("{}")
-		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, badRequest+"\n")
-	})
-
-	Convey("When a json message is sent to update filter blueprint that doesn't exist, a status of not found is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1}}`)
-		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When no authentication is provided to update an unpublished filter, a not found is returned", t, func() {
-		reader := strings.NewReader(`{"dimensions":[]}`)
-		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When a json message is sent to change the dataset version of a filter blueprint and the version does not exist, a status of bad request is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":2}}`)
-		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad request - version not found\n")
-	})
-
-	Convey("When a json message is sent to change the datset version of a filter blueprint and the current dimensions do not match, a status of bad request is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":2}}`)
-		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [time]\n")
-	})
-
-	Convey("When a json message is sent to change the dataset version of a filter blueprint and the current dimension options do not match, a status of bad request is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":2}}`)
-		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [28]\n")
-	})
-}
-
-func TestSuccessfulGetFilterBlueprintDimensions(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully get a list of dimensions for a filter blueprint", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-
-	Convey("Successfully get a list of dimensions for an unpublished filter blueprint", t, func() {
-		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-}
-
-func TestFailedToGetFilterBlueprintDimensions(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-}
-
-func TestSuccessfulGetFilterBlueprintDimension(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully get a dimension for a filter blueprint, returns 204", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNoContent)
-	})
-
-	Convey("Successfully get a dimension for an unpublished filter blueprint, returns 204", t, func() {
-		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNoContent)
-	})
-}
-
-func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, statusBadRequest+"\n")
-	})
-
-	Convey("When filter blueprint is unpublished and request is unauthenticated, a not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Dimension not found\n")
-	})
-}
-
-func TestSuccessfulGetFilterBlueprintDimensionOptions(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully get a list of dimension options for a filter blueprint", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-
-	Convey("Successfully get a list of dimension options for an unpublished filter blueprint", t, func() {
-		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options", nil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-}
-
-func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age/options", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/123/dimensions/1_age/options", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When filter blueprint is unpublished and the request is unauthenticated, a not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/123/dimensions/1_age/options", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When dimension does not exist against filter blueprint, a dimension not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Dimension not found\n")
-	})
-}
-
-func TestSuccessfulGetFilterBlueprintDimensionOption(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully get a single dimension option for a filter blueprint", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNoContent)
-	})
-
-	Convey("Successfully get a single dimension option for an unpublished filter blueprint", t, func() {
-		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNoContent)
-	})
-}
-
-func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age/options/26", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, statusBadRequest+"\n")
-	})
-
-	Convey("When filter blueprint is unpublished, a not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When option does not exist against filter blueprint, an option not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/age/options/notanage", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Option not found\n")
-	})
-}
-
-func TestSuccessfulRemoveFilterBlueprintDimension(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully remove a dimension for a filter blueprint, returns 200", t, func() {
-		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-
-	Convey("Successfully remove a dimension for an unpublished filter blueprint, returns 200", t, func() {
-		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-}
-
-func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/1234568/dimensions/1_age", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
-		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, statusBadRequest+"\n")
-	})
-
-	Convey("When filter blueprint is unpublished, and request is not authenticated, a bad request is returned", t, func() {
-		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
-		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-}
-
-func TestSuccessfulRemoveFilterBlueprintDimensionOption(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully remove a option for a filter blueprint, returns 200", t, func() {
-		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-
-	Convey("Successfully remove a option for an unpublished filter blueprint, returns 200", t, func() {
-		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-}
-
-func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
-		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, statusBadRequest+"\n")
-	})
-
-	Convey("When filter blueprint is unpublished, and request is not authenticated, a not found is returned", t, func() {
-		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter blueprint not found\n")
-	})
-
-	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
-		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Dimension not found\n")
-	})
-}
+// func TestSuccessfulAddFilterBlueprint(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully create a filter blueprint", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusCreated)
+// 	})
+//
+// 	Convey("Successfully create a filter blueprint for an unpublished version", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
+// 		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusCreated)
+// 	})
+//
+// 	Convey("Successfully create a filter blueprint with dimensions", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusCreated)
+// 	})
+//
+// 	//	TODO check test doesn't actually write job to queue?
+// 	Convey("Successfully submit a filter blueprint", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters?submitted=true", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusCreated)
+// 	})
+// }
+//
+// func TestFailedToAddFilterBlueprint(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When dataset API is unavailable, an internal error is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{InternalServerError: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When version does not exist, a not found error is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Version not found\n")
+// 	})
+//
+// 	Convey("When version is unpublished and the request is not authenticated, a bad request error is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, badRequest+"\n")
+// 	})
+//
+// 	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
+// 		reader := strings.NewReader("{")
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, badRequest+"\n")
+// 	})
+//
+// 	Convey("When a empty json message is sent, a bad request is returned", t, func() {
+// 		reader := strings.NewReader("{}")
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, badRequest+"\n")
+// 	})
+//
+// 	Convey("When a json message is missing mandatory fields, a bad request is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":"Census"}`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, badRequest+"\n")
+// 	})
+//
+// 	Convey("When a json message contains a dimension that does not exist, a bad request is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} , "dimensions":[{"name": "weight", "options": ["27","33"]}]}`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [weight]\n")
+// 	})
+//
+// 	Convey("When a json message contains a dimension option that does not exist for a valid dimension, a bad request is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} , "dimensions":[{"name": "age", "options": ["29","33"]}]}`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [29]\n")
+// 	})
+// }
+//
+// func TestSuccessfulAddFilterBlueprintDimension(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully create a dimension with an empty request body", t, func() {
+// 		reader := strings.NewReader("")
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusCreated)
+// 	})
+//
+// 	Convey("Successfully create a dimension with a request body but no options", t, func() {
+// 		reader := strings.NewReader("{}")
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusCreated)
+// 	})
+//
+// 	Convey("Successfully create a dimension with options", t, func() {
+// 		reader := strings.NewReader(`{"options":["27","33"]}`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusCreated)
+// 	})
+//
+// 	Convey("Successfully create a dimension with options for an unpublished filter", t, func() {
+// 		reader := strings.NewReader(`{"options":["27","33"]}`)
+// 		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusCreated)
+// 	})
+// }
+//
+// func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		reader := strings.NewReader(`{"options":["22","17"]}`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
+// 		reader := strings.NewReader("{")
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, badRequest+"\n")
+// 	})
+//
+// 	Convey("When a filter blueprint does not exist, a not found is returned", t, func() {
+// 		reader := strings.NewReader(`{"options":["22","17"]}`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When an unpublished filter blueprint does not exist, and the request is not authenticated, a not found is returned", t, func() {
+// 		reader := strings.NewReader(`{"options":["22","17"]}`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When the dimension does not exist against the dataset filtered on, a bad request is returned", t, func() {
+// 		reader := strings.NewReader(`{"options":["22","17"]}`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/wealth", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [wealth]\n")
+// 	})
+//
+// 	Convey("When a json body contains a dimension option that does not exist for a valid dimension, a bad request is returned", t, func() {
+// 		reader := strings.NewReader(`{"options":["22","33"]}`)
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [22]\n")
+// 	})
+// }
+//
+// func TestSuccessfulAddFilterBlueprintDimensionOption(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully add a dimension option to a filter", t, func() {
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusCreated)
+// 	})
+//
+// 	Convey("Successfully add a dimension option to an unpublished filter", t, func() {
+// 		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusCreated)
+// 	})
+// }
+//
+// func TestFailedToAddFilterBlueprintDimensionOption_DimensionDoesNotExist(t *testing.T) {
+//
+// 	Convey("When a dimension for filter blueprint does not exist, a bad request status is returned", t, func() {
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/notage/options/33", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [notage]\n")
+// 	})
+// }
+//
+// func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When the filter blueprint does not exist, a bad request status is returned", t, func() {
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, statusBadRequest+"\n")
+// 	})
+//
+// 	Convey("When the filter blueprint is unpublished, and the request is unauthenticated, a not found status is returned", t, func() {
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When the dimension option for filter blueprint does not exist, a bad request status is returned", t, func() {
+// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/66", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [66]\n")
+// 	})
+// }
+//
+// func TestSuccessfulGetFilterBlueprint(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully get a published filter blueprint with no authentication", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+//
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+//
+// 	Convey("Successfully get an unpublished filter blueprint with authentication", t, func() {
+// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678", nil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+//
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+// }
+//
+// func TestFailedToGetFilterBlueprint(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+//
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When filter blueprint is unpublished, and the request is unauthenticated, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+// }
+//
+// func TestSuccessfulUpdateFilterBlueprint(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully send a valid json message", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1}}`)
+// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+//
+// 	Convey("Successfully send a valid json message with events and dataset version update", t, func() {
+//
+// 		updateBlueprintData := `{"dataset":{"version":1}, "events":{"info":[{"time":"` + time.Now().String() +
+// 			`","type":"something changed","message":"something happened"}],"error":[{"time":"` + time.Now().String() +
+// 			`","type":"errored","message":"something errored"}]}}`
+//
+// 		reader := strings.NewReader(updateBlueprintData)
+// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+//
+// 	Convey("Successfully send a request to submit filter blueprint", t, func() {
+// 		reader := strings.NewReader("{}")
+// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312?submitted=true", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+//
+// 	Convey("Successfully send a request to submit an unpublished filter blueprint", t, func() {
+// 		reader := strings.NewReader("{}")
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filters/21312?submitted=true", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+// }
+//
+// func TestFailedToUpdateFilterBlueprint(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
+// 		reader := strings.NewReader("{")
+// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, badRequest+"\n")
+// 	})
+//
+// 	Convey("When an empty json message is sent, a bad request is returned", t, func() {
+// 		reader := strings.NewReader("{}")
+// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, badRequest+"\n")
+// 	})
+//
+// 	Convey("When a json message is sent to update filter blueprint that doesn't exist, a status of not found is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1}}`)
+// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When no authentication is provided to update an unpublished filter, a not found is returned", t, func() {
+// 		reader := strings.NewReader(`{"dimensions":[]}`)
+// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+//
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When a json message is sent to change the dataset version of a filter blueprint and the version does not exist, a status of bad request is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":2}}`)
+// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Bad request - version not found\n")
+// 	})
+//
+// 	Convey("When a json message is sent to change the datset version of a filter blueprint and the current dimensions do not match, a status of bad request is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":2}}`)
+// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [time]\n")
+// 	})
+//
+// 	Convey("When a json message is sent to change the dataset version of a filter blueprint and the current dimension options do not match, a status of bad request is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":2}}`)
+// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [28]\n")
+// 	})
+// }
+//
+// func TestSuccessfulGetFilterBlueprintDimensions(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully get a list of dimensions for a filter blueprint", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+//
+// 	Convey("Successfully get a list of dimensions for an unpublished filter blueprint", t, func() {
+// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+// }
+//
+// func TestFailedToGetFilterBlueprintDimensions(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+// }
+//
+// func TestSuccessfulGetFilterBlueprintDimension(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully get a dimension for a filter blueprint, returns 204", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNoContent)
+// 	})
+//
+// 	Convey("Successfully get a dimension for an unpublished filter blueprint, returns 204", t, func() {
+// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNoContent)
+// 	})
+// }
+//
+// func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, statusBadRequest+"\n")
+// 	})
+//
+// 	Convey("When filter blueprint is unpublished and request is unauthenticated, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Dimension not found\n")
+// 	})
+// }
+//
+// func TestSuccessfulGetFilterBlueprintDimensionOptions(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully get a list of dimension options for a filter blueprint", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+//
+// 	Convey("Successfully get a list of dimension options for an unpublished filter blueprint", t, func() {
+// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options", nil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+// }
+//
+// func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age/options", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/123/dimensions/1_age/options", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When filter blueprint is unpublished and the request is unauthenticated, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/123/dimensions/1_age/options", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When dimension does not exist against filter blueprint, a dimension not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Dimension not found\n")
+// 	})
+// }
+//
+// func TestSuccessfulGetFilterBlueprintDimensionOption(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully get a single dimension option for a filter blueprint", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNoContent)
+// 	})
+//
+// 	Convey("Successfully get a single dimension option for an unpublished filter blueprint", t, func() {
+// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNoContent)
+// 	})
+// }
+//
+// func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age/options/26", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, statusBadRequest+"\n")
+// 	})
+//
+// 	Convey("When filter blueprint is unpublished, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When option does not exist against filter blueprint, an option not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/age/options/notanage", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Option not found\n")
+// 	})
+// }
+//
+// func TestSuccessfulRemoveFilterBlueprintDimension(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully remove a dimension for a filter blueprint, returns 200", t, func() {
+// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+//
+// 	Convey("Successfully remove a dimension for an unpublished filter blueprint, returns 200", t, func() {
+// 		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+// }
+//
+// func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/1234568/dimensions/1_age", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
+// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, statusBadRequest+"\n")
+// 	})
+//
+// 	Convey("When filter blueprint is unpublished, and request is not authenticated, a bad request is returned", t, func() {
+// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+// }
+//
+// func TestSuccessfulRemoveFilterBlueprintDimensionOption(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully remove a option for a filter blueprint, returns 200", t, func() {
+// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+//
+// 	Convey("Successfully remove a option for an unpublished filter blueprint, returns 200", t, func() {
+// 		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+// }
+//
+// func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
+// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, statusBadRequest+"\n")
+// 	})
+//
+// 	Convey("When filter blueprint is unpublished, and request is not authenticated, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter blueprint not found\n")
+// 	})
+//
+// 	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Dimension not found\n")
+// 	})
+// }
 
 func TestSuccessfulGetFilterOutput(t *testing.T) {
 	t.Parallel()
-	Convey("Successfully get a filter output", t, func() {
+	Convey("Successfully get a filter output from an unauthenticated request", t, func() {
 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
 		So(err, ShouldBeNil)
 
@@ -1149,6 +1148,47 @@ func TestSuccessfulGetFilterOutput(t *testing.T) {
 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
+
+		// Check private link is hidden for unauthenticated user
+		jsonResult, err := ioutil.ReadAll(w.Body)
+		if err != nil {
+			t.Logf("failed to read filter output response body, error: [%v]", err.Error())
+			t.Fail()
+		}
+
+		filterOutput := &models.Filter{}
+		if err = json.Unmarshal(jsonResult, filterOutput); err != nil {
+			t.Logf("failed to marshal filte output json response, error: [%v]", err.Error())
+			t.Fail()
+		}
+
+		So(filterOutput.Downloads.CSV, ShouldResemble, &models.DownloadItem{HRef: "ons-test-site.gov.uk/87654321.csv", Private: "", Public: "csv-public-link", Size: "12mb"})
+		So(filterOutput.Downloads.XLS, ShouldResemble, &models.DownloadItem{HRef: "ons-test-site.gov.uk/87654321.xls", Private: "", Public: "xls-public-link", Size: "24mb"})
+	})
+
+	Convey("Successfully get a filter output from an authenticated request", t, func() {
+		r := createAuthenticatedRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+
+		// Check private link is NOT hidden from authenticated user
+		jsonResult, err := ioutil.ReadAll(w.Body)
+		if err != nil {
+			t.Logf("failed to read filter output response body, error: [%v]", err.Error())
+			t.Fail()
+		}
+
+		filterOutput := &models.Filter{}
+		if err = json.Unmarshal(jsonResult, filterOutput); err != nil {
+			t.Logf("failed to marshal filte output json response, error: [%v]", err.Error())
+			t.Fail()
+		}
+
+		So(filterOutput.Downloads.CSV, ShouldResemble, &models.DownloadItem{HRef: "ons-test-site.gov.uk/87654321.csv", Private: "csv-private-link", Public: "csv-public-link", Size: "12mb"})
+		So(filterOutput.Downloads.XLS, ShouldResemble, &models.DownloadItem{HRef: "ons-test-site.gov.uk/87654321.xls", Private: "xls-private-link", Public: "xls-public-link", Size: "24mb"})
 	})
 
 	Convey("Successfully get an unpublished filter output", t, func() {
@@ -1161,294 +1201,371 @@ func TestSuccessfulGetFilterOutput(t *testing.T) {
 	})
 }
 
-func TestFailedToGetFilterOutput(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/1234568", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When filter output does not exist, a not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter output not found\n")
-	})
-
-	Convey("When filter output is unpublished and the request is unauthenticated, a not found is returned", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter output not found\n")
-	})
-}
-
-func TestSuccessfulUpdateFilterOutput(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully send a valid json message", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"url":"s3-csv-location","size":"12mb"}}}`)
-		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-}
-
-func TestSuccessfulUpdateFilterOutputUnpublished(t *testing.T) {
-	t.Parallel()
-
-	Convey("Successfully send a valid json message to update an unpublished filter output", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"url":"s3-csv-location","size":"12mb"}}}`)
-		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-	})
-}
-
-func TestFailedToUpdateFilterOutput(t *testing.T) {
-	t.Parallel()
-	Convey("When no data store is available, an internal error is returned", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"url":"s3-csv-location","size":"12mb"}}}`)
-		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
-		reader := strings.NewReader("{")
-		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, badRequest+"\n")
-	})
-
-	Convey("When an update to a filter output resource that does not exist, a not found is returned", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"url":"s3-csv-location","size":"12mb"}}}`)
-		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-	})
-
-	Convey("When a empty json message is sent, a bad request is returned", t, func() {
-		reader := strings.NewReader("{}")
-		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, badRequest+"\n")
-	})
-
-	Convey("When a json message contains fields that are not allowed to be updated, a forbidden status is returned", t, func() {
-		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}}`)
-		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusForbidden)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Forbidden from updating the following fields: [dataset.id dataset.edition dataset.version]\n")
-	})
-
-	Convey("When a json message is sent to change a filter output with the wrong authorisation header, an unauthorised status is returned", t, func() {
-		reader := strings.NewReader(`{"downloads":{"csv":{"url":"s3-csv-location","size":"12mb"}}}`)
-		r, err := http.NewRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "resource not found\n")
-	})
-}
-
-func TestSuccessfulGetPreview(t *testing.T) {
-	t.Parallel()
-	Convey("Successfully requesting a valid preview", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-		So(previewMock.GetPreviewCalls()[0].Limit, ShouldEqual, 20)
-	})
-
-	Convey("Successfully requesting a valid preview for unpublished version filters", t, func() {
-		r := createAuthenticatedRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-		So(previewMock.GetPreviewCalls()[0].Limit, ShouldEqual, 20)
-	})
-
-	Convey("Successfully requesting a valid preview with a new limit", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=10", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		previewMockForLimit := &datastoretest.PreviewDatasetMock{
-			GetPreviewFunc: func(filter *models.Filter, limit int) (*preview.FilterPreview, error) {
-				return &preview.FilterPreview{}, nil
-			},
-		}
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockForLimit)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-		So(previewMockForLimit.GetPreviewCalls()[0].Limit, ShouldEqual, 10)
-	})
-}
-
-func TestFailedGetPreview(t *testing.T) {
-	t.Parallel()
-	Convey("Requesting a preview with invalid filter", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusNotFound)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "Filter output not found\n")
-	})
-
-	Convey("Requesting a preview with no mongodb database connection", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, internalError+"\n")
-	})
-
-	Convey("Requesting a preview with no neo4j database connection", t, func() {
-		previewMockInternalError := &datastoretest.PreviewDatasetMock{
-			GetPreviewFunc: func(filter *models.Filter, limit int) (*preview.FilterPreview, error) {
-				return nil, errors.New("internal error")
-			},
-		}
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockInternalError)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "internal server error\n")
-	})
-
-	Convey("Requesting a preview with no dimensions", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "no dimensions are present in the filter\n")
-	})
-
-	Convey("Requesting a preview with an invalid limit", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=a", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "requested limit is not a number\n")
-	})
-
-	Convey("Requesting a preview with no authentication when the version is unpublished", t, func() {
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=a", nil)
-		So(err, ShouldBeNil)
-
-		w := httptest.NewRecorder()
-		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
-		So(response, ShouldResemble, "requested limit is not a number\n")
-	})
-}
+// func TestFailedToGetFilterOutput(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/1234568", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+//
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When filter output does not exist, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter output not found\n")
+// 	})
+//
+// 	Convey("When filter output is unpublished and the request is unauthenticated, a not found is returned", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter output not found\n")
+// 	})
+// }
+//
+// func TestSuccessfulUpdateFilterOutput(t *testing.T) {
+// 	t.Parallel()
+//
+// 	Convey("Successfully update filter output when public csv download link is missing", t, func() {
+// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+//
+// 	Convey("Successfully update filter output when public xls download link is missing", t, func() {
+// 		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-xls-location","size":"12mb", "public":"s3-public-xls-location"}}}`)
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+// }
+//
+// func TestSuccessfulUpdateFilterOutputUnpublished(t *testing.T) {
+// 	t.Parallel()
+//
+// 	Convey("Successfully update filter output with private csv download link when version is unpublished", t, func() {
+// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "private": "s3-private-csv-location"}}}`)
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+//
+// 	Convey("Successfully update filter output with private xls download link when version is unpublished", t, func() {
+// 		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-csv-location","size":"12mb", "private":"s3-private-xls-location"}}}`)
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 	})
+// }
+//
+// func TestFailedToUpdateFilterOutput(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("When no data store is available, an internal error is returned", t, func() {
+// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
+// 		reader := strings.NewReader("{")
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, badRequest+"\n")
+// 	})
+//
+// 	Convey("When an update to a filter output resource that does not exist, a not found is returned", t, func() {
+// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+// 	})
+//
+// 	Convey("When a empty json message is sent, a bad request is returned", t, func() {
+// 		reader := strings.NewReader("{}")
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, badRequest+"\n")
+// 	})
+//
+// 	Convey("When a json message contains fields that are not allowed to be updated, a forbidden status is returned", t, func() {
+// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}}`)
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusForbidden)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Forbidden from updating the following fields: [dataset.id dataset.edition dataset.version]\n")
+// 	})
+//
+// 	Convey("When a json message is sent to change a filter output with the wrong authorisation header, an unauthorised status is returned", t, func() {
+// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "resource not found\n")
+// 	})
+//
+// 	Convey("When a json message contains downloads object but current filter ouput has public csv download links already and version is published, than a forbidden status is returned", t, func() {
+// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusForbidden)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.csv]\n")
+// 	})
+//
+// 	Convey("When a json message contains downloads object but current filter ouput has public xls download links already and version is published, than a forbidden status is returned", t, func() {
+// 		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-xls-location","size":"12mb", "public":"s3-public-xls-location"}}}`)
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusForbidden)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.xls]\n")
+// 	})
+//
+// 	Convey("When a json message contains private csv link but current filter ouput has private csv download links already and version is published, than a forbidden status is returned", t, func() {
+// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "private":"s3-private-csv-location"}}}`)
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusForbidden)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.csv.private]\n")
+// 	})
+//
+// 	Convey("When a json message contains private xls link but current filter ouput has private xls download links already and version is published, than a forbidden status is returned", t, func() {
+// 		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-xls-location","size":"12mb", "private":"s3-private-xls-location"}}}`)
+// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusForbidden)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.xls.private]\n")
+// 	})
+// }
+//
+// func TestSuccessfulGetPreview(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Successfully requesting a valid preview", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 		So(previewMock.GetPreviewCalls()[0].Limit, ShouldEqual, 20)
+// 	})
+//
+// 	Convey("Successfully requesting a valid preview for unpublished version filters", t, func() {
+// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 		So(previewMock.GetPreviewCalls()[0].Limit, ShouldEqual, 20)
+// 	})
+//
+// 	Convey("Successfully requesting a valid preview with a new limit", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=10", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		previewMockForLimit := &datastoretest.PreviewDatasetMock{
+// 			GetPreviewFunc: func(filter *models.Filter, limit int) (*preview.FilterPreview, error) {
+// 				return &preview.FilterPreview{}, nil
+// 			},
+// 		}
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockForLimit)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusOK)
+// 		So(previewMockForLimit.GetPreviewCalls()[0].Limit, ShouldEqual, 10)
+// 	})
+// }
+//
+// func TestFailedGetPreview(t *testing.T) {
+// 	t.Parallel()
+// 	Convey("Requesting a preview with invalid filter", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusNotFound)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "Filter output not found\n")
+// 	})
+//
+// 	Convey("Requesting a preview with no mongodb database connection", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, internalError+"\n")
+// 	})
+//
+// 	Convey("Requesting a preview with no neo4j database connection", t, func() {
+// 		previewMockInternalError := &datastoretest.PreviewDatasetMock{
+// 			GetPreviewFunc: func(filter *models.Filter, limit int) (*preview.FilterPreview, error) {
+// 				return nil, errors.New("internal error")
+// 			},
+// 		}
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockInternalError)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "internal server error\n")
+// 	})
+//
+// 	Convey("Requesting a preview with no dimensions", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "no dimensions are present in the filter\n")
+// 	})
+//
+// 	Convey("Requesting a preview with an invalid limit", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=a", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "requested limit is not a number\n")
+// 	})
+//
+// 	Convey("Requesting a preview with no authentication when the version is unpublished", t, func() {
+// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=a", nil)
+// 		So(err, ShouldBeNil)
+//
+// 		w := httptest.NewRecorder()
+// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+// 		api.router.ServeHTTP(w, r)
+// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+//
+// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
+// 		response := string(bodyBytes)
+// 		So(response, ShouldResemble, "requested limit is not a number\n")
+// 	})
+// }
 
 func createAuthenticatedRequest(method, url string, body io.Reader) *http.Request {
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"io"
 
@@ -28,1115 +31,1115 @@ var previewMock = &datastoretest.PreviewDatasetMock{
 	},
 }
 
-// func TestSuccessfulAddFilterBlueprint(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully create a filter blueprint", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusCreated)
-// 	})
-//
-// 	Convey("Successfully create a filter blueprint for an unpublished version", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
-// 		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusCreated)
-// 	})
-//
-// 	Convey("Successfully create a filter blueprint with dimensions", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusCreated)
-// 	})
-//
-// 	//	TODO check test doesn't actually write job to queue?
-// 	Convey("Successfully submit a filter blueprint", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters?submitted=true", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusCreated)
-// 	})
-// }
-//
-// func TestFailedToAddFilterBlueprint(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When dataset API is unavailable, an internal error is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{InternalServerError: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When version does not exist, a not found error is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Version not found\n")
-// 	})
-//
-// 	Convey("When version is unpublished and the request is not authenticated, a bad request error is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, badRequest+"\n")
-// 	})
-//
-// 	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
-// 		reader := strings.NewReader("{")
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, badRequest+"\n")
-// 	})
-//
-// 	Convey("When a empty json message is sent, a bad request is returned", t, func() {
-// 		reader := strings.NewReader("{}")
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, badRequest+"\n")
-// 	})
-//
-// 	Convey("When a json message is missing mandatory fields, a bad request is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":"Census"}`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, badRequest+"\n")
-// 	})
-//
-// 	Convey("When a json message contains a dimension that does not exist, a bad request is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} , "dimensions":[{"name": "weight", "options": ["27","33"]}]}`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [weight]\n")
-// 	})
-//
-// 	Convey("When a json message contains a dimension option that does not exist for a valid dimension, a bad request is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} , "dimensions":[{"name": "age", "options": ["29","33"]}]}`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [29]\n")
-// 	})
-// }
-//
-// func TestSuccessfulAddFilterBlueprintDimension(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully create a dimension with an empty request body", t, func() {
-// 		reader := strings.NewReader("")
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusCreated)
-// 	})
-//
-// 	Convey("Successfully create a dimension with a request body but no options", t, func() {
-// 		reader := strings.NewReader("{}")
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusCreated)
-// 	})
-//
-// 	Convey("Successfully create a dimension with options", t, func() {
-// 		reader := strings.NewReader(`{"options":["27","33"]}`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusCreated)
-// 	})
-//
-// 	Convey("Successfully create a dimension with options for an unpublished filter", t, func() {
-// 		reader := strings.NewReader(`{"options":["27","33"]}`)
-// 		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusCreated)
-// 	})
-// }
-//
-// func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		reader := strings.NewReader(`{"options":["22","17"]}`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
-// 		reader := strings.NewReader("{")
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, badRequest+"\n")
-// 	})
-//
-// 	Convey("When a filter blueprint does not exist, a not found is returned", t, func() {
-// 		reader := strings.NewReader(`{"options":["22","17"]}`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When an unpublished filter blueprint does not exist, and the request is not authenticated, a not found is returned", t, func() {
-// 		reader := strings.NewReader(`{"options":["22","17"]}`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When the dimension does not exist against the dataset filtered on, a bad request is returned", t, func() {
-// 		reader := strings.NewReader(`{"options":["22","17"]}`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/wealth", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [wealth]\n")
-// 	})
-//
-// 	Convey("When a json body contains a dimension option that does not exist for a valid dimension, a bad request is returned", t, func() {
-// 		reader := strings.NewReader(`{"options":["22","33"]}`)
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [22]\n")
-// 	})
-// }
-//
-// func TestSuccessfulAddFilterBlueprintDimensionOption(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully add a dimension option to a filter", t, func() {
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusCreated)
-// 	})
-//
-// 	Convey("Successfully add a dimension option to an unpublished filter", t, func() {
-// 		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusCreated)
-// 	})
-// }
-//
-// func TestFailedToAddFilterBlueprintDimensionOption_DimensionDoesNotExist(t *testing.T) {
-//
-// 	Convey("When a dimension for filter blueprint does not exist, a bad request status is returned", t, func() {
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/notage/options/33", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [notage]\n")
-// 	})
-// }
-//
-// func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When the filter blueprint does not exist, a bad request status is returned", t, func() {
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, statusBadRequest+"\n")
-// 	})
-//
-// 	Convey("When the filter blueprint is unpublished, and the request is unauthenticated, a not found status is returned", t, func() {
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When the dimension option for filter blueprint does not exist, a bad request status is returned", t, func() {
-// 		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/66", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [66]\n")
-// 	})
-// }
-//
-// func TestSuccessfulGetFilterBlueprint(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully get a published filter blueprint with no authentication", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-//
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-//
-// 	Convey("Successfully get an unpublished filter blueprint with authentication", t, func() {
-// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678", nil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-//
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-// }
-//
-// func TestFailedToGetFilterBlueprint(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-//
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When filter blueprint is unpublished, and the request is unauthenticated, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-// }
-//
-// func TestSuccessfulUpdateFilterBlueprint(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully send a valid json message", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1}}`)
-// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-//
-// 	Convey("Successfully send a valid json message with events and dataset version update", t, func() {
-//
-// 		updateBlueprintData := `{"dataset":{"version":1}, "events":{"info":[{"time":"` + time.Now().String() +
-// 			`","type":"something changed","message":"something happened"}],"error":[{"time":"` + time.Now().String() +
-// 			`","type":"errored","message":"something errored"}]}}`
-//
-// 		reader := strings.NewReader(updateBlueprintData)
-// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-//
-// 	Convey("Successfully send a request to submit filter blueprint", t, func() {
-// 		reader := strings.NewReader("{}")
-// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312?submitted=true", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-//
-// 	Convey("Successfully send a request to submit an unpublished filter blueprint", t, func() {
-// 		reader := strings.NewReader("{}")
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filters/21312?submitted=true", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-// }
-//
-// func TestFailedToUpdateFilterBlueprint(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
-// 		reader := strings.NewReader("{")
-// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, badRequest+"\n")
-// 	})
-//
-// 	Convey("When an empty json message is sent, a bad request is returned", t, func() {
-// 		reader := strings.NewReader("{}")
-// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, badRequest+"\n")
-// 	})
-//
-// 	Convey("When a json message is sent to update filter blueprint that doesn't exist, a status of not found is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1}}`)
-// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When no authentication is provided to update an unpublished filter, a not found is returned", t, func() {
-// 		reader := strings.NewReader(`{"dimensions":[]}`)
-// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-//
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When a json message is sent to change the dataset version of a filter blueprint and the version does not exist, a status of bad request is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":2}}`)
-// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Bad request - version not found\n")
-// 	})
-//
-// 	Convey("When a json message is sent to change the datset version of a filter blueprint and the current dimensions do not match, a status of bad request is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":2}}`)
-// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [time]\n")
-// 	})
-//
-// 	Convey("When a json message is sent to change the dataset version of a filter blueprint and the current dimension options do not match, a status of bad request is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":2}}`)
-// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [28]\n")
-// 	})
-// }
-//
-// func TestSuccessfulGetFilterBlueprintDimensions(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully get a list of dimensions for a filter blueprint", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-//
-// 	Convey("Successfully get a list of dimensions for an unpublished filter blueprint", t, func() {
-// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-// }
-//
-// func TestFailedToGetFilterBlueprintDimensions(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-// }
-//
-// func TestSuccessfulGetFilterBlueprintDimension(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully get a dimension for a filter blueprint, returns 204", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNoContent)
-// 	})
-//
-// 	Convey("Successfully get a dimension for an unpublished filter blueprint, returns 204", t, func() {
-// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNoContent)
-// 	})
-// }
-//
-// func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, statusBadRequest+"\n")
-// 	})
-//
-// 	Convey("When filter blueprint is unpublished and request is unauthenticated, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Dimension not found\n")
-// 	})
-// }
-//
-// func TestSuccessfulGetFilterBlueprintDimensionOptions(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully get a list of dimension options for a filter blueprint", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-//
-// 	Convey("Successfully get a list of dimension options for an unpublished filter blueprint", t, func() {
-// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options", nil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-// }
-//
-// func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age/options", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/123/dimensions/1_age/options", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When filter blueprint is unpublished and the request is unauthenticated, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/123/dimensions/1_age/options", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When dimension does not exist against filter blueprint, a dimension not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Dimension not found\n")
-// 	})
-// }
-//
-// func TestSuccessfulGetFilterBlueprintDimensionOption(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully get a single dimension option for a filter blueprint", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNoContent)
-// 	})
-//
-// 	Convey("Successfully get a single dimension option for an unpublished filter blueprint", t, func() {
-// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNoContent)
-// 	})
-// }
-//
-// func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age/options/26", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, statusBadRequest+"\n")
-// 	})
-//
-// 	Convey("When filter blueprint is unpublished, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When option does not exist against filter blueprint, an option not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/age/options/notanage", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Option not found\n")
-// 	})
-// }
-//
-// func TestSuccessfulRemoveFilterBlueprintDimension(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully remove a dimension for a filter blueprint, returns 200", t, func() {
-// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-//
-// 	Convey("Successfully remove a dimension for an unpublished filter blueprint, returns 200", t, func() {
-// 		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-// }
-//
-// func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/1234568/dimensions/1_age", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
-// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, statusBadRequest+"\n")
-// 	})
-//
-// 	Convey("When filter blueprint is unpublished, and request is not authenticated, a bad request is returned", t, func() {
-// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-// }
-//
-// func TestSuccessfulRemoveFilterBlueprintDimensionOption(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully remove a option for a filter blueprint, returns 200", t, func() {
-// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-//
-// 	Convey("Successfully remove a option for an unpublished filter blueprint, returns 200", t, func() {
-// 		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-// }
-//
-// func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
-// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, statusBadRequest+"\n")
-// 	})
-//
-// 	Convey("When filter blueprint is unpublished, and request is not authenticated, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter blueprint not found\n")
-// 	})
-//
-// 	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Dimension not found\n")
-// 	})
-// }
+func TestSuccessfulAddFilterBlueprint(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully create a filter blueprint", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusCreated)
+	})
+
+	Convey("Successfully create a filter blueprint for an unpublished version", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
+		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusCreated)
+	})
+
+	Convey("Successfully create a filter blueprint with dimensions", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusCreated)
+	})
+
+	//	TODO check test doesn't actually write job to queue?
+	Convey("Successfully submit a filter blueprint", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters?submitted=true", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusCreated)
+	})
+}
+
+func TestFailedToAddFilterBlueprint(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When dataset API is unavailable, an internal error is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{InternalServerError: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When version does not exist, a not found error is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} }`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Version not found\n")
+	})
+
+	Convey("When version is unpublished and the request is not authenticated, a bad request error is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}, "dimensions":[{"name": "age", "options": ["27","33"]}]}`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, badRequest+"\n")
+	})
+
+	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
+		reader := strings.NewReader("{")
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, badRequest+"\n")
+	})
+
+	Convey("When a empty json message is sent, a bad request is returned", t, func() {
+		reader := strings.NewReader("{}")
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, badRequest+"\n")
+	})
+
+	Convey("When a json message is missing mandatory fields, a bad request is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":"Census"}`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, badRequest+"\n")
+	})
+
+	Convey("When a json message contains a dimension that does not exist, a bad request is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} , "dimensions":[{"name": "weight", "options": ["27","33"]}]}`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [weight]\n")
+	})
+
+	Convey("When a json message contains a dimension option that does not exist for a valid dimension, a bad request is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"} , "dimensions":[{"name": "age", "options": ["29","33"]}]}`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [29]\n")
+	})
+}
+
+func TestSuccessfulAddFilterBlueprintDimension(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully create a dimension with an empty request body", t, func() {
+		reader := strings.NewReader("")
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusCreated)
+	})
+
+	Convey("Successfully create a dimension with a request body but no options", t, func() {
+		reader := strings.NewReader("{}")
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusCreated)
+	})
+
+	Convey("Successfully create a dimension with options", t, func() {
+		reader := strings.NewReader(`{"options":["27","33"]}`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusCreated)
+	})
+
+	Convey("Successfully create a dimension with options for an unpublished filter", t, func() {
+		reader := strings.NewReader(`{"options":["27","33"]}`)
+		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusCreated)
+	})
+}
+
+func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		reader := strings.NewReader(`{"options":["22","17"]}`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
+		reader := strings.NewReader("{")
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, badRequest+"\n")
+	})
+
+	Convey("When a filter blueprint does not exist, a not found is returned", t, func() {
+		reader := strings.NewReader(`{"options":["22","17"]}`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When an unpublished filter blueprint does not exist, and the request is not authenticated, a not found is returned", t, func() {
+		reader := strings.NewReader(`{"options":["22","17"]}`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When the dimension does not exist against the dataset filtered on, a bad request is returned", t, func() {
+		reader := strings.NewReader(`{"options":["22","17"]}`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/wealth", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [wealth]\n")
+	})
+
+	Convey("When a json body contains a dimension option that does not exist for a valid dimension, a bad request is returned", t, func() {
+		reader := strings.NewReader(`{"options":["22","33"]}`)
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [22]\n")
+	})
+}
+
+func TestSuccessfulAddFilterBlueprintDimensionOption(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully add a dimension option to a filter", t, func() {
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusCreated)
+	})
+
+	Convey("Successfully add a dimension option to an unpublished filter", t, func() {
+		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusCreated)
+	})
+}
+
+func TestFailedToAddFilterBlueprintDimensionOption_DimensionDoesNotExist(t *testing.T) {
+
+	Convey("When a dimension for filter blueprint does not exist, a bad request status is returned", t, func() {
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/notage/options/33", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [notage]\n")
+	})
+}
+
+func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When the filter blueprint does not exist, a bad request status is returned", t, func() {
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, statusBadRequest+"\n")
+	})
+
+	Convey("When the filter blueprint is unpublished, and the request is unauthenticated, a not found status is returned", t, func() {
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When the dimension option for filter blueprint does not exist, a bad request status is returned", t, func() {
+		r, err := http.NewRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/66", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [66]\n")
+	})
+}
+
+func TestSuccessfulGetFilterBlueprint(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully get a published filter blueprint with no authentication", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully get an unpublished filter blueprint with authentication", t, func() {
+		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678", nil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+}
+
+func TestFailedToGetFilterBlueprint(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When filter blueprint is unpublished, and the request is unauthenticated, a not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+}
+
+func TestSuccessfulUpdateFilterBlueprint(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully send a valid json message", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1}}`)
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully send a valid json message with events and dataset version update", t, func() {
+
+		updateBlueprintData := `{"dataset":{"version":1}, "events":{"info":[{"time":"` + time.Now().String() +
+			`","type":"something changed","message":"something happened"}],"error":[{"time":"` + time.Now().String() +
+			`","type":"errored","message":"something errored"}]}}`
+
+		reader := strings.NewReader(updateBlueprintData)
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{ChangeInstanceRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully send a request to submit filter blueprint", t, func() {
+		reader := strings.NewReader("{}")
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312?submitted=true", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully send a request to submit an unpublished filter blueprint", t, func() {
+		reader := strings.NewReader("{}")
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filters/21312?submitted=true", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+}
+
+func TestFailedToUpdateFilterBlueprint(t *testing.T) {
+	t.Parallel()
+	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
+		reader := strings.NewReader("{")
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, badRequest+"\n")
+	})
+
+	Convey("When an empty json message is sent, a bad request is returned", t, func() {
+		reader := strings.NewReader("{}")
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, badRequest+"\n")
+	})
+
+	Convey("When a json message is sent to update filter blueprint that doesn't exist, a status of not found is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1}}`)
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When no authentication is provided to update an unpublished filter, a not found is returned", t, func() {
+		reader := strings.NewReader(`{"dimensions":[]}`)
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When a json message is sent to change the dataset version of a filter blueprint and the version does not exist, a status of bad request is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":2}}`)
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{VersionNotFound: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Bad request - version not found\n")
+	})
+
+	Convey("When a json message is sent to change the datset version of a filter blueprint and the current dimensions do not match, a status of bad request is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":2}}`)
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [time]\n")
+	})
+
+	Convey("When a json message is sent to change the dataset version of a filter blueprint and the current dimension options do not match, a status of bad request is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":2}}`)
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filters/21312", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [28]\n")
+	})
+}
+
+func TestSuccessfulGetFilterBlueprintDimensions(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully get a list of dimensions for a filter blueprint", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully get a list of dimensions for an unpublished filter blueprint", t, func() {
+		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+}
+
+func TestFailedToGetFilterBlueprintDimensions(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+}
+
+func TestSuccessfulGetFilterBlueprintDimension(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully get a dimension for a filter blueprint, returns 204", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNoContent)
+	})
+
+	Convey("Successfully get a dimension for an unpublished filter blueprint, returns 204", t, func() {
+		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNoContent)
+	})
+}
+
+func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, statusBadRequest+"\n")
+	})
+
+	Convey("When filter blueprint is unpublished and request is unauthenticated, a not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Dimension not found\n")
+	})
+}
+
+func TestSuccessfulGetFilterBlueprintDimensionOptions(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully get a list of dimension options for a filter blueprint", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully get a list of dimension options for an unpublished filter blueprint", t, func() {
+		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options", nil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+}
+
+func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age/options", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When filter blueprint does not exist, a not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/123/dimensions/1_age/options", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When filter blueprint is unpublished and the request is unauthenticated, a not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/123/dimensions/1_age/options", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When dimension does not exist against filter blueprint, a dimension not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Dimension not found\n")
+	})
+}
+
+func TestSuccessfulGetFilterBlueprintDimensionOption(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully get a single dimension option for a filter blueprint", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNoContent)
+	})
+
+	Convey("Successfully get a single dimension option for an unpublished filter blueprint", t, func() {
+		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNoContent)
+	})
+}
+
+func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/1234568/dimensions/1_age/options/26", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, statusBadRequest+"\n")
+	})
+
+	Convey("When filter blueprint is unpublished, a not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When option does not exist against filter blueprint, an option not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filters/12345678/dimensions/age/options/notanage", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Option not found\n")
+	})
+}
+
+func TestSuccessfulRemoveFilterBlueprintDimension(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully remove a dimension for a filter blueprint, returns 200", t, func() {
+		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully remove a dimension for an unpublished filter blueprint, returns 200", t, func() {
+		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+}
+
+func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/1234568/dimensions/1_age", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
+		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, statusBadRequest+"\n")
+	})
+
+	Convey("When filter blueprint is unpublished, and request is not authenticated, a bad request is returned", t, func() {
+		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
+		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+}
+
+func TestSuccessfulRemoveFilterBlueprintDimensionOption(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully remove a option for a filter blueprint, returns 200", t, func() {
+		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully remove a option for an unpublished filter blueprint, returns 200", t, func() {
+		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+}
+
+func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When filter blueprint does not exist, a bad request is returned", t, func() {
+		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, statusBadRequest+"\n")
+	})
+
+	Convey("When filter blueprint is unpublished, and request is not authenticated, a not found is returned", t, func() {
+		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter blueprint not found\n")
+	})
+
+	Convey("When dimension does not exist against filter blueprint, a not found is returned", t, func() {
+		r, err := http.NewRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age/options/26", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Dimension not found\n")
+	})
+}
 
 func TestSuccessfulGetFilterOutput(t *testing.T) {
 	t.Parallel()
@@ -1201,371 +1204,371 @@ func TestSuccessfulGetFilterOutput(t *testing.T) {
 	})
 }
 
-// func TestFailedToGetFilterOutput(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/1234568", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-//
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When filter output does not exist, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter output not found\n")
-// 	})
-//
-// 	Convey("When filter output is unpublished and the request is unauthenticated, a not found is returned", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter output not found\n")
-// 	})
-// }
-//
-// func TestSuccessfulUpdateFilterOutput(t *testing.T) {
-// 	t.Parallel()
-//
-// 	Convey("Successfully update filter output when public csv download link is missing", t, func() {
-// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-//
-// 	Convey("Successfully update filter output when public xls download link is missing", t, func() {
-// 		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-xls-location","size":"12mb", "public":"s3-public-xls-location"}}}`)
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-// }
-//
-// func TestSuccessfulUpdateFilterOutputUnpublished(t *testing.T) {
-// 	t.Parallel()
-//
-// 	Convey("Successfully update filter output with private csv download link when version is unpublished", t, func() {
-// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "private": "s3-private-csv-location"}}}`)
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-//
-// 	Convey("Successfully update filter output with private xls download link when version is unpublished", t, func() {
-// 		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-csv-location","size":"12mb", "private":"s3-private-xls-location"}}}`)
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 	})
-// }
-//
-// func TestFailedToUpdateFilterOutput(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("When no data store is available, an internal error is returned", t, func() {
-// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
-// 		reader := strings.NewReader("{")
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, badRequest+"\n")
-// 	})
-//
-// 	Convey("When an update to a filter output resource that does not exist, a not found is returned", t, func() {
-// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-// 	})
-//
-// 	Convey("When a empty json message is sent, a bad request is returned", t, func() {
-// 		reader := strings.NewReader("{}")
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, badRequest+"\n")
-// 	})
-//
-// 	Convey("When a json message contains fields that are not allowed to be updated, a forbidden status is returned", t, func() {
-// 		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}}`)
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusForbidden)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Forbidden from updating the following fields: [dataset.id dataset.edition dataset.version]\n")
-// 	})
-//
-// 	Convey("When a json message is sent to change a filter output with the wrong authorisation header, an unauthorised status is returned", t, func() {
-// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
-// 		r, err := http.NewRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "resource not found\n")
-// 	})
-//
-// 	Convey("When a json message contains downloads object but current filter ouput has public csv download links already and version is published, than a forbidden status is returned", t, func() {
-// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusForbidden)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.csv]\n")
-// 	})
-//
-// 	Convey("When a json message contains downloads object but current filter ouput has public xls download links already and version is published, than a forbidden status is returned", t, func() {
-// 		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-xls-location","size":"12mb", "public":"s3-public-xls-location"}}}`)
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusForbidden)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.xls]\n")
-// 	})
-//
-// 	Convey("When a json message contains private csv link but current filter ouput has private csv download links already and version is published, than a forbidden status is returned", t, func() {
-// 		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "private":"s3-private-csv-location"}}}`)
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusForbidden)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.csv.private]\n")
-// 	})
-//
-// 	Convey("When a json message contains private xls link but current filter ouput has private xls download links already and version is published, than a forbidden status is returned", t, func() {
-// 		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-xls-location","size":"12mb", "private":"s3-private-xls-location"}}}`)
-// 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusForbidden)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.xls.private]\n")
-// 	})
-// }
-//
-// func TestSuccessfulGetPreview(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Successfully requesting a valid preview", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 		So(previewMock.GetPreviewCalls()[0].Limit, ShouldEqual, 20)
-// 	})
-//
-// 	Convey("Successfully requesting a valid preview for unpublished version filters", t, func() {
-// 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 		So(previewMock.GetPreviewCalls()[0].Limit, ShouldEqual, 20)
-// 	})
-//
-// 	Convey("Successfully requesting a valid preview with a new limit", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=10", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		previewMockForLimit := &datastoretest.PreviewDatasetMock{
-// 			GetPreviewFunc: func(filter *models.Filter, limit int) (*preview.FilterPreview, error) {
-// 				return &preview.FilterPreview{}, nil
-// 			},
-// 		}
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockForLimit)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusOK)
-// 		So(previewMockForLimit.GetPreviewCalls()[0].Limit, ShouldEqual, 10)
-// 	})
-// }
-//
-// func TestFailedGetPreview(t *testing.T) {
-// 	t.Parallel()
-// 	Convey("Requesting a preview with invalid filter", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusNotFound)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "Filter output not found\n")
-// 	})
-//
-// 	Convey("Requesting a preview with no mongodb database connection", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, internalError+"\n")
-// 	})
-//
-// 	Convey("Requesting a preview with no neo4j database connection", t, func() {
-// 		previewMockInternalError := &datastoretest.PreviewDatasetMock{
-// 			GetPreviewFunc: func(filter *models.Filter, limit int) (*preview.FilterPreview, error) {
-// 				return nil, errors.New("internal error")
-// 			},
-// 		}
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockInternalError)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "internal server error\n")
-// 	})
-//
-// 	Convey("Requesting a preview with no dimensions", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "no dimensions are present in the filter\n")
-// 	})
-//
-// 	Convey("Requesting a preview with an invalid limit", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=a", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "requested limit is not a number\n")
-// 	})
-//
-// 	Convey("Requesting a preview with no authentication when the version is unpublished", t, func() {
-// 		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=a", nil)
-// 		So(err, ShouldBeNil)
-//
-// 		w := httptest.NewRecorder()
-// 		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
-// 		api.router.ServeHTTP(w, r)
-// 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-//
-// 		bodyBytes, _ := ioutil.ReadAll(w.Body)
-// 		response := string(bodyBytes)
-// 		So(response, ShouldResemble, "requested limit is not a number\n")
-// 	})
-// }
+func TestFailedToGetFilterOutput(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/1234568", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When filter output does not exist, a not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter output not found\n")
+	})
+
+	Convey("When filter output is unpublished and the request is unauthenticated, a not found is returned", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter output not found\n")
+	})
+}
+
+func TestSuccessfulUpdateFilterOutput(t *testing.T) {
+	t.Parallel()
+
+	Convey("Successfully update filter output when public csv download link is missing", t, func() {
+		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully update filter output when public xls download link is missing", t, func() {
+		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-xls-location","size":"12mb", "public":"s3-public-xls-location"}}}`)
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+}
+
+func TestSuccessfulUpdateFilterOutputUnpublished(t *testing.T) {
+	t.Parallel()
+
+	Convey("Successfully update filter output with private csv download link when version is unpublished", t, func() {
+		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "private": "s3-private-csv-location"}}}`)
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully update filter output with private xls download link when version is unpublished", t, func() {
+		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-csv-location","size":"12mb", "private":"s3-private-xls-location"}}}`)
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+}
+
+func TestFailedToUpdateFilterOutput(t *testing.T) {
+	t.Parallel()
+	Convey("When no data store is available, an internal error is returned", t, func() {
+		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("When an invalid json message is sent, a bad request is returned", t, func() {
+		reader := strings.NewReader("{")
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, badRequest+"\n")
+	})
+
+	Convey("When an update to a filter output resource that does not exist, a not found is returned", t, func() {
+		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+	})
+
+	Convey("When a empty json message is sent, a bad request is returned", t, func() {
+		reader := strings.NewReader("{}")
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, badRequest+"\n")
+	})
+
+	Convey("When a json message contains fields that are not allowed to be updated, a forbidden status is returned", t, func() {
+		reader := strings.NewReader(`{"dataset":{"version":1, "edition":"1", "id":"1"}}`)
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusForbidden)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Forbidden from updating the following fields: [dataset.id dataset.edition dataset.version]\n")
+	})
+
+	Convey("When a json message is sent to change a filter output with the wrong authorisation header, an unauthorised status is returned", t, func() {
+		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+		r, err := http.NewRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "resource not found\n")
+	})
+
+	Convey("When a json message contains downloads object but current filter ouput has public csv download links already and version is published, than a forbidden status is returned", t, func() {
+		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "public":"s3-public-csv-location"}}}`)
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusForbidden)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.csv]\n")
+	})
+
+	Convey("When a json message contains downloads object but current filter ouput has public xls download links already and version is published, than a forbidden status is returned", t, func() {
+		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-xls-location","size":"12mb", "public":"s3-public-xls-location"}}}`)
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusForbidden)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.xls]\n")
+	})
+
+	Convey("When a json message contains private csv link but current filter ouput has private csv download links already and version is published, than a forbidden status is returned", t, func() {
+		reader := strings.NewReader(`{"downloads":{"csv":{"href":"s3-csv-location","size":"12mb", "private":"s3-private-csv-location"}}}`)
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusForbidden)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.csv.private]\n")
+	})
+
+	Convey("When a json message contains private xls link but current filter ouput has private xls download links already and version is published, than a forbidden status is returned", t, func() {
+		reader := strings.NewReader(`{"downloads":{"xls":{"href":"s3-xls-location","size":"12mb", "private":"s3-private-xls-location"}}}`)
+		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusForbidden)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.xls.private]\n")
+	})
+}
+
+func TestSuccessfulGetPreview(t *testing.T) {
+	t.Parallel()
+	Convey("Successfully requesting a valid preview", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+		So(previewMock.GetPreviewCalls()[0].Limit, ShouldEqual, 20)
+	})
+
+	Convey("Successfully requesting a valid preview for unpublished version filters", t, func() {
+		r := createAuthenticatedRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+		So(previewMock.GetPreviewCalls()[0].Limit, ShouldEqual, 20)
+	})
+
+	Convey("Successfully requesting a valid preview with a new limit", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=10", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		previewMockForLimit := &datastoretest.PreviewDatasetMock{
+			GetPreviewFunc: func(filter *models.Filter, limit int) (*preview.FilterPreview, error) {
+				return &preview.FilterPreview{}, nil
+			},
+		}
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockForLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+		So(previewMockForLimit.GetPreviewCalls()[0].Limit, ShouldEqual, 10)
+	})
+}
+
+func TestFailedGetPreview(t *testing.T) {
+	t.Parallel()
+	Convey("Requesting a preview with invalid filter", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "Filter output not found\n")
+	})
+
+	Convey("Requesting a preview with no mongodb database connection", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, internalError+"\n")
+	})
+
+	Convey("Requesting a preview with no neo4j database connection", t, func() {
+		previewMockInternalError := &datastoretest.PreviewDatasetMock{
+			GetPreviewFunc: func(filter *models.Filter, limit int) (*preview.FilterPreview, error) {
+				return nil, errors.New("internal error")
+			},
+		}
+		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMockInternalError)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "internal server error\n")
+	})
+
+	Convey("Requesting a preview with no dimensions", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "no dimensions are present in the filter\n")
+	})
+
+	Convey("Requesting a preview with an invalid limit", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=a", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "requested limit is not a number\n")
+	})
+
+	Convey("Requesting a preview with no authentication when the version is unpublished", t, func() {
+		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/21312/preview?limit=a", nil)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := routes(host, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		bodyBytes, _ := ioutil.ReadAll(w.Body)
+		response := string(bodyBytes)
+		So(response, ShouldResemble, "requested limit is not a number\n")
+	})
+}
 
 func createAuthenticatedRequest(method, url string, body io.Reader) *http.Request {
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -91,8 +90,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -106,8 +104,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -121,8 +118,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Version not found\n")
 	})
 
@@ -136,8 +132,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, badRequest+"\n")
 	})
 
@@ -151,8 +146,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, badRequest+"\n")
 	})
 
@@ -166,8 +160,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, badRequest+"\n")
 	})
 
@@ -181,8 +174,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, badRequest+"\n")
 	})
 
@@ -196,8 +188,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [weight]\n")
 	})
 
@@ -211,8 +202,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [29]\n")
 	})
 }
@@ -275,8 +265,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -290,8 +279,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, badRequest+"\n")
 	})
 
@@ -305,8 +293,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -320,8 +307,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -335,8 +321,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [wealth]\n")
 	})
 
@@ -350,8 +335,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [22]\n")
 	})
 }
@@ -389,8 +373,7 @@ func TestFailedToAddFilterBlueprintDimensionOption_DimensionDoesNotExist(t *test
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [notage]\n")
 	})
 }
@@ -406,8 +389,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -420,8 +402,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, statusBadRequest+"\n")
 	})
 
@@ -434,8 +415,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -448,8 +428,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [66]\n")
 	})
 }
@@ -490,8 +469,7 @@ func TestFailedToGetFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -504,8 +482,7 @@ func TestFailedToGetFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -518,8 +495,7 @@ func TestFailedToGetFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 }
@@ -587,8 +563,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, badRequest+"\n")
 	})
 
@@ -602,8 +577,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, badRequest+"\n")
 	})
 
@@ -617,8 +591,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -633,8 +606,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -648,8 +620,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Bad request - version not found\n")
 	})
 
@@ -663,8 +634,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Bad request - incorrect dimensions chosen: [time]\n")
 	})
 
@@ -678,8 +648,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Bad request - incorrect dimension options chosen: [28]\n")
 	})
 }
@@ -717,8 +686,7 @@ func TestFailedToGetFilterBlueprintDimensions(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -731,8 +699,7 @@ func TestFailedToGetFilterBlueprintDimensions(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 }
@@ -770,8 +737,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -784,8 +750,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, statusBadRequest+"\n")
 	})
 
@@ -798,8 +763,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -812,8 +776,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Dimension not found\n")
 	})
 }
@@ -851,8 +814,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -865,8 +827,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -879,8 +840,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -893,8 +853,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Dimension not found\n")
 	})
 }
@@ -932,8 +891,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -946,8 +904,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, statusBadRequest+"\n")
 	})
 
@@ -960,8 +917,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -974,8 +930,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Option not found\n")
 	})
 }
@@ -1013,8 +968,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -1027,8 +981,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, statusBadRequest+"\n")
 	})
 
@@ -1041,8 +994,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -1055,8 +1007,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 }
@@ -1094,8 +1045,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -1108,8 +1058,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, statusBadRequest+"\n")
 	})
 
@@ -1122,8 +1071,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter blueprint not found\n")
 	})
 
@@ -1136,8 +1084,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Dimension not found\n")
 	})
 }
@@ -1154,11 +1101,7 @@ func TestSuccessfulGetFilterOutput(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusOK)
 
 		// Check private link is hidden for unauthenticated user
-		jsonResult, err := ioutil.ReadAll(w.Body)
-		if err != nil {
-			t.Logf("failed to read filter output response body, error: [%v]", err.Error())
-			t.Fail()
-		}
+		jsonResult := w.Body.Bytes()
 
 		filterOutput := &models.Filter{}
 		if err = json.Unmarshal(jsonResult, filterOutput); err != nil {
@@ -1179,14 +1122,10 @@ func TestSuccessfulGetFilterOutput(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusOK)
 
 		// Check private link is NOT hidden from authenticated user
-		jsonResult, err := ioutil.ReadAll(w.Body)
-		if err != nil {
-			t.Logf("failed to read filter output response body, error: [%v]", err.Error())
-			t.Fail()
-		}
+		jsonResult := w.Body.Bytes()
 
 		filterOutput := &models.Filter{}
-		if err = json.Unmarshal(jsonResult, filterOutput); err != nil {
+		if err := json.Unmarshal(jsonResult, filterOutput); err != nil {
 			t.Logf("failed to marshal filte output json response, error: [%v]", err.Error())
 			t.Fail()
 		}
@@ -1217,8 +1156,7 @@ func TestFailedToGetFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -1231,8 +1169,7 @@ func TestFailedToGetFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter output not found\n")
 	})
 
@@ -1245,8 +1182,7 @@ func TestFailedToGetFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter output not found\n")
 	})
 }
@@ -1311,8 +1247,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -1325,8 +1260,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, badRequest+"\n")
 	})
 
@@ -1349,8 +1283,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, badRequest+"\n")
 	})
 
@@ -1363,8 +1296,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Forbidden from updating the following fields: [dataset.id dataset.edition dataset.version]\n")
 	})
 
@@ -1378,8 +1310,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "resource not found\n")
 	})
 
@@ -1392,8 +1323,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.csv]\n")
 	})
 
@@ -1406,8 +1336,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.xls]\n")
 	})
 
@@ -1420,8 +1349,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.csv.private]\n")
 	})
 
@@ -1434,8 +1362,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Forbidden from updating the following fields: [downloads.xls.private]\n")
 	})
 }
@@ -1504,8 +1431,7 @@ func TestFailedGetPreview(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "Filter output not found\n")
 	})
 
@@ -1518,8 +1444,7 @@ func TestFailedGetPreview(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, internalError+"\n")
 	})
 
@@ -1537,8 +1462,7 @@ func TestFailedGetPreview(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "internal server error\n")
 	})
 
@@ -1551,8 +1475,7 @@ func TestFailedGetPreview(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "no dimensions are present in the filter\n")
 	})
 
@@ -1565,8 +1488,7 @@ func TestFailedGetPreview(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "requested limit is not a number\n")
 	})
 
@@ -1579,8 +1501,7 @@ func TestFailedGetPreview(t *testing.T) {
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
-		bodyBytes, _ := ioutil.ReadAll(w.Body)
-		response := string(bodyBytes)
+		response := w.Body.String()
 		So(response, ShouldResemble, "requested limit is not a number\n")
 	})
 }

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -60,7 +60,7 @@ var (
 // GetVersion queries the Dataset API to get an version
 func (api *DatasetAPI) GetVersion(ctx context.Context, d models.Dataset) (version *models.Version, err error) {
 	path := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%d", api.url, d.ID, d.Edition, d.Version)
-	logData := log.Data{"func": "GetDataset", "URL": path, "dataset": d}
+	logData := log.Data{"func": "GetVersion", "URL": path, "dataset": d}
 
 	jsonResult, httpCode, err := api.get(ctx, path, nil)
 	logData["httpCode"] = httpCode

--- a/api/dataset.go
+++ b/api/dataset.go
@@ -52,9 +52,14 @@ var (
 	ErrVersionNotFound          = errors.New("Version not found")
 	ErrDimensionNotFound        = errors.New("Dimension not found")
 	ErrDimensionOptionsNotFound = errors.New("Dimension options not found")
+)
 
+var (
 	publishedState  = "published"
 	versionNotFound = "Version not found"
+
+	dimensionType = "dimension"
+	versionType   = "version"
 )
 
 // GetVersion queries the Dataset API to get an version
@@ -97,9 +102,9 @@ func (api *DatasetAPI) GetVersionDimensions(ctx context.Context, dataset models.
 	logData["jsonResult"] = jsonResult
 	if err != nil {
 		log.ErrorC("GetVersionDimensions api get", err, logData)
-		typ := "dimension"
+		typ := dimensionType
 		if jsonResult == versionNotFound {
-			typ = "version"
+			typ = versionType
 		}
 		return nil, handleError(httpCode, err, typ)
 	}
@@ -124,9 +129,9 @@ func (api *DatasetAPI) GetVersionDimensionOptions(ctx context.Context, dataset m
 	logData["jsonResult"] = jsonResult
 	if err != nil {
 		log.ErrorC("GetVersionDimensionOptions api get", err, logData)
-		typ := "dimension"
+		typ := dimensionType
 		if jsonResult == versionNotFound {
-			typ = "version"
+			typ = versionType
 		}
 		return nil, handleError(httpCode, err, typ)
 	}
@@ -188,7 +193,7 @@ func (api *DatasetAPI) callDatasetAPI(ctx context.Context, method, path string, 
 		return nil, 0, err
 	}
 	defer func() {
-		err := resp.Body.Close()
+		err = resp.Body.Close()
 		if err != nil {
 			log.ErrorC("error cleaning up request body", err, logData)
 		}

--- a/api/filters.go
+++ b/api/filters.go
@@ -902,7 +902,7 @@ func (api *FilterAPI) getFilter(ctx context.Context, filterID string) (*models.F
 	}
 
 	//only return the filter if it is for published data or via authenticated request
-	if filter.Published == &models.Published || identity.IsPresent(ctx) {
+	if filter.Published != nil && *filter.Published == models.Published || identity.IsPresent(ctx) {
 		return filter, nil
 	}
 
@@ -950,7 +950,7 @@ func (api *FilterAPI) getOutput(ctx context.Context, filterID string) (*models.F
 	}
 
 	//only return the filter if it is for published data or via authenticated request
-	if output.Published == &models.Published || identity.IsPresent(ctx) {
+	if output.Published != nil && *output.Published == models.Published || identity.IsPresent(ctx) {
 		return output, nil
 	}
 
@@ -963,7 +963,7 @@ func (api *FilterAPI) getOutput(ctx context.Context, filterID string) (*models.F
 	}
 
 	//filter has been published since output was last requested, so update output and return
-	if filter.Published == &models.Published {
+	if filter.Published != nil && *filter.Published == models.Published {
 		output.Published = &models.Published
 		if err := api.dataStore.UpdateFilterOutput(output); err != nil {
 			log.Error(err, log.Data{"filter_output_id": output.FilterID})

--- a/api/filters.go
+++ b/api/filters.go
@@ -775,7 +775,9 @@ func (api *FilterAPI) updateFilterOutput(w http.ResponseWriter, r *http.Request)
 
 	filterOutput.FilterID = filterOutputID
 
-	if err = api.dataStore.UpdateFilterOutput(filterOutput); err != nil {
+	filterOutputUpdate := buildDownloadsObject(previousFilterOutput, filterOutput)
+
+	if err = api.dataStore.UpdateFilterOutput(filterOutputUpdate); err != nil {
 		log.ErrorC("unable to update filter blueprint", err, logData)
 		setErrorCode(w, err)
 		return
@@ -1063,6 +1065,57 @@ func (api *FilterAPI) checkNewFilterDimension(ctx context.Context, name string, 
 	}
 
 	return nil
+}
+
+func buildDownloadsObject(previousFilterOutput, filterOutput *models.Filter) *models.Filter {
+	if previousFilterOutput.Downloads == nil {
+		return filterOutput
+	}
+
+	if filterOutput.Downloads == nil {
+		filterOutput.Downloads = previousFilterOutput.Downloads
+		return filterOutput
+	}
+
+	if previousFilterOutput.Downloads.CSV != nil {
+		if filterOutput.Downloads.CSV == nil {
+			filterOutput.Downloads.CSV = previousFilterOutput.Downloads.CSV
+		} else {
+			if filterOutput.Downloads.CSV.HRef == "" {
+				filterOutput.Downloads.CSV.HRef = previousFilterOutput.Downloads.CSV.HRef
+			}
+			if filterOutput.Downloads.CSV.Size == "" {
+				filterOutput.Downloads.CSV.Size = previousFilterOutput.Downloads.CSV.Size
+			}
+			if filterOutput.Downloads.CSV.Private == "" {
+				filterOutput.Downloads.CSV.Private = previousFilterOutput.Downloads.CSV.Private
+			}
+			if filterOutput.Downloads.CSV.Public == "" {
+				filterOutput.Downloads.CSV.Public = previousFilterOutput.Downloads.CSV.Public
+			}
+		}
+	}
+
+	if previousFilterOutput.Downloads.XLS != nil {
+		if filterOutput.Downloads.XLS == nil {
+			filterOutput.Downloads.XLS = previousFilterOutput.Downloads.XLS
+		} else {
+			if filterOutput.Downloads.XLS.HRef == "" {
+				filterOutput.Downloads.XLS.HRef = previousFilterOutput.Downloads.XLS.HRef
+			}
+			if filterOutput.Downloads.XLS.Size == "" {
+				filterOutput.Downloads.XLS.Size = previousFilterOutput.Downloads.XLS.Size
+			}
+			if filterOutput.Downloads.XLS.Private == "" {
+				filterOutput.Downloads.XLS.Private = previousFilterOutput.Downloads.XLS.Private
+			}
+			if filterOutput.Downloads.XLS.Public == "" {
+				filterOutput.Downloads.XLS.Public = previousFilterOutput.Downloads.XLS.Public
+			}
+		}
+	}
+
+	return filterOutput
 }
 
 func setJSONContentType(w http.ResponseWriter) {

--- a/api/filters_test.go
+++ b/api/filters_test.go
@@ -1,0 +1,247 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-filter-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var testOptions = []struct {
+	inputPreviousFilterOutput *models.Filter
+	inputFilterOutput         *models.Filter
+	expectedOutput            *models.Filter
+}{
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: nil},
+		inputFilterOutput:         &models.Filter{Downloads: &fullDownloads},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloads},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: &fullDownloads},
+		inputFilterOutput:         &models.Filter{Downloads: nil},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloads},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: nil},
+		inputFilterOutput:         &models.Filter{Downloads: &csvDownloadsOnly},
+		expectedOutput:            &models.Filter{Downloads: &csvDownloadsOnly},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: nil},
+		inputFilterOutput:         &models.Filter{Downloads: &xlsDownloadsOnly},
+		expectedOutput:            &models.Filter{Downloads: &xlsDownloadsOnly},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloads},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloads},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[1].csv}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[0].csv}},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[2].csv}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[1].csv}},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[3].csv}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[2].csv}},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[1].xls}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[3].xls}},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[2].xls}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[4].xls}},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[3].xls}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[5].xls}},
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv, XLS: &xlsScenario[0].xls}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[3].csv, XLS: &xlsScenario[3].xls}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[2].csv, XLS: &expectedDownloadItems[5].xls}},
+	},
+}
+
+func TestBuildDownloadsObject(t *testing.T) {
+
+	Convey("Successfully build download object", t, func() {
+
+		for _, option := range testOptions {
+			filterOutput := buildDownloadsObject(option.inputPreviousFilterOutput, option.inputFilterOutput)
+			So(filterOutput, ShouldResemble, option.expectedOutput)
+		}
+	})
+}
+
+// Test data
+var (
+	fullDownloads models.Downloads = models.Downloads{
+		CSV: &models.DownloadItem{
+			HRef:    "csv-downloads-link",
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link",
+			Size:    "12mb",
+		},
+		XLS: &models.DownloadItem{
+			HRef:    "xls-downloads-link",
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link",
+			Size:    "24mb",
+		},
+	}
+
+	csvDownloadsOnly models.Downloads = models.Downloads{
+		CSV: &models.DownloadItem{
+			HRef:    "csv-downloads-link",
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link",
+			Size:    "12mb",
+		},
+		XLS: nil,
+	}
+
+	xlsDownloadsOnly models.Downloads = models.Downloads{
+		XLS: &models.DownloadItem{
+			HRef:    "xls-downloads-link",
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link",
+			Size:    "24mb",
+		},
+		CSV: nil,
+	}
+)
+
+var xlsScenario = []struct {
+	xls models.DownloadItem
+}{
+	{
+		xls: models.DownloadItem{
+			HRef:    "xls-downloads-link",
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link",
+			Size:    "24mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			HRef:    "xls-downloads-link-2",
+			Private: "xls-private-downloads-link-2",
+			Size:    "34mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			HRef:   "xls-downloads-link-3",
+			Public: "xls-public-downloads-link-3",
+			Size:   "44mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			Public: "xls-public-downloads-link-4",
+		},
+	},
+}
+
+var csvScenario = []struct {
+	csv models.DownloadItem
+}{
+	{
+		csv: models.DownloadItem{
+			HRef:    "csv-downloads-link",
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link",
+			Size:    "12mb",
+		},
+	},
+	{
+		csv: models.DownloadItem{
+			HRef:    "csv-downloads-link-2",
+			Private: "csv-private-downloads-link-2",
+			Size:    "24mb",
+		},
+	},
+	{
+		csv: models.DownloadItem{
+			HRef:   "csv-downloads-link-3",
+			Public: "csv-public-downloads-link-3",
+			Size:   "34mb",
+		},
+	},
+	{
+		csv: models.DownloadItem{
+			Public: "csv-public-downloads-link-4",
+		},
+	},
+}
+
+var expectedDownloadItems = []struct {
+	csv models.DownloadItem
+	xls models.DownloadItem
+}{
+	{
+		csv: models.DownloadItem{
+			HRef:    "csv-downloads-link-2",
+			Private: "csv-private-downloads-link-2",
+			Public:  "csv-public-downloads-link",
+			Size:    "24mb",
+		},
+	},
+	{
+		csv: models.DownloadItem{
+			HRef:    "csv-downloads-link-3",
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link-3",
+			Size:    "34mb",
+		},
+	},
+	{
+		csv: models.DownloadItem{
+			HRef:    "csv-downloads-link",
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link-4",
+			Size:    "12mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			HRef:    "xls-downloads-link-2",
+			Private: "xls-private-downloads-link-2",
+			Public:  "xls-public-downloads-link",
+			Size:    "34mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			HRef:    "xls-downloads-link-3",
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link-3",
+			Size:    "44mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			HRef:    "xls-downloads-link",
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link-4",
+			Size:    "24mb",
+		},
+	},
+}

--- a/api/filters_test.go
+++ b/api/filters_test.go
@@ -7,75 +7,95 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const (
+	filterID1 = "121"
+	filterID2 = "122"
+	filterID3 = "123"
+)
+
 var testOptions = []struct {
 	inputPreviousFilterOutput *models.Filter
 	inputFilterOutput         *models.Filter
 	expectedOutput            *models.Filter
+	title                     string
 }{
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: nil},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: nil},
 		inputFilterOutput:         &models.Filter{Downloads: &fullDownloads},
-		expectedOutput:            &models.Filter{Downloads: &fullDownloads},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
+		title:                     "1",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: &fullDownloads},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &fullDownloads},
 		inputFilterOutput:         &models.Filter{Downloads: nil},
-		expectedOutput:            &models.Filter{Downloads: &fullDownloads},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
+		title:                     "2",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: nil},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: nil},
 		inputFilterOutput:         &models.Filter{Downloads: &csvDownloadsOnly},
-		expectedOutput:            &models.Filter{Downloads: &csvDownloadsOnly},
+		expectedOutput:            &models.Filter{Downloads: &csvDownloadsOnlyOutputs},
+		title:                     "3",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: nil},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: nil},
 		inputFilterOutput:         &models.Filter{Downloads: &xlsDownloadsOnly},
-		expectedOutput:            &models.Filter{Downloads: &xlsDownloadsOnly},
+		expectedOutput:            &models.Filter{Downloads: &xlsDownloadsOnlyOutputs},
+		title:                     "4",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
 		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
-		expectedOutput:            &models.Filter{Downloads: &fullDownloads},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
+		title:                     "5",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
 		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
-		expectedOutput:            &models.Filter{Downloads: &fullDownloads},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
+		title:                     "6",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID2, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
 		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[1].csv}},
 		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[0].csv}},
+		title:                     "7",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID3, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
 		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[2].csv}},
 		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[1].csv}},
+		title:                     "8",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
 		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[3].csv}},
 		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[2].csv}},
+		title:                     "9",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID2, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
 		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[1].xls}},
 		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[3].xls}},
+		title:                     "10",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID3, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
 		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[2].xls}},
 		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[4].xls}},
+		title:                     "11",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
 		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[3].xls}},
 		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[5].xls}},
+		title:                     "12",
 	},
 	{
-		inputPreviousFilterOutput: &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv, XLS: &xlsScenario[0].xls}},
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{CSV: &csvScenario[0].csv, XLS: &xlsScenario[0].xls}},
 		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[3].csv, XLS: &xlsScenario[3].xls}},
 		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[2].csv, XLS: &expectedDownloadItems[5].xls}},
+		title:                     "13",
 	},
 }
 
@@ -84,32 +104,31 @@ func TestBuildDownloadsObject(t *testing.T) {
 	Convey("Successfully build download object", t, func() {
 
 		for _, option := range testOptions {
-			filterOutput := buildDownloadsObject(option.inputPreviousFilterOutput, option.inputFilterOutput)
-			So(filterOutput, ShouldResemble, option.expectedOutput)
+			Convey(option.title, func() {
+				filterOutput := buildDownloadsObject(option.inputPreviousFilterOutput, option.inputFilterOutput, downloadServiceURL)
+				So(filterOutput, ShouldResemble, option.expectedOutput)
+			})
 		}
 	})
 }
 
 // Test data
 var (
-	fullDownloads models.Downloads = models.Downloads{
+	fullDownloads = models.Downloads{
 		CSV: &models.DownloadItem{
-			HRef:    "csv-downloads-link",
 			Private: "csv-private-downloads-link",
 			Public:  "csv-public-downloads-link",
 			Size:    "12mb",
 		},
 		XLS: &models.DownloadItem{
-			HRef:    "xls-downloads-link",
 			Private: "xls-private-downloads-link",
 			Public:  "xls-public-downloads-link",
 			Size:    "24mb",
 		},
 	}
 
-	csvDownloadsOnly models.Downloads = models.Downloads{
+	csvDownloadsOnly = models.Downloads{
 		CSV: &models.DownloadItem{
-			HRef:    "csv-downloads-link",
 			Private: "csv-private-downloads-link",
 			Public:  "csv-public-downloads-link",
 			Size:    "12mb",
@@ -117,9 +136,43 @@ var (
 		XLS: nil,
 	}
 
-	xlsDownloadsOnly models.Downloads = models.Downloads{
+	xlsDownloadsOnly = models.Downloads{
 		XLS: &models.DownloadItem{
-			HRef:    "xls-downloads-link",
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link",
+			Size:    "24mb",
+		},
+		CSV: nil,
+	}
+
+	fullDownloadsOutputs = models.Downloads{
+		CSV: &models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link",
+			Size:    "12mb",
+		},
+		XLS: &models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".xlsx",
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link",
+			Size:    "24mb",
+		},
+	}
+
+	csvDownloadsOnlyOutputs = models.Downloads{
+		CSV: &models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link",
+			Size:    "12mb",
+		},
+		XLS: nil,
+	}
+
+	xlsDownloadsOnlyOutputs = models.Downloads{
+		XLS: &models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".xlsx",
 			Private: "xls-private-downloads-link",
 			Public:  "xls-public-downloads-link",
 			Size:    "24mb",
@@ -133,7 +186,6 @@ var xlsScenario = []struct {
 }{
 	{
 		xls: models.DownloadItem{
-			HRef:    "xls-downloads-link",
 			Private: "xls-private-downloads-link",
 			Public:  "xls-public-downloads-link",
 			Size:    "24mb",
@@ -141,14 +193,12 @@ var xlsScenario = []struct {
 	},
 	{
 		xls: models.DownloadItem{
-			HRef:    "xls-downloads-link-2",
 			Private: "xls-private-downloads-link-2",
 			Size:    "34mb",
 		},
 	},
 	{
 		xls: models.DownloadItem{
-			HRef:   "xls-downloads-link-3",
 			Public: "xls-public-downloads-link-3",
 			Size:   "44mb",
 		},
@@ -165,7 +215,7 @@ var csvScenario = []struct {
 }{
 	{
 		csv: models.DownloadItem{
-			HRef:    "csv-downloads-link",
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
 			Private: "csv-private-downloads-link",
 			Public:  "csv-public-downloads-link",
 			Size:    "12mb",
@@ -173,14 +223,12 @@ var csvScenario = []struct {
 	},
 	{
 		csv: models.DownloadItem{
-			HRef:    "csv-downloads-link-2",
 			Private: "csv-private-downloads-link-2",
 			Size:    "24mb",
 		},
 	},
 	{
 		csv: models.DownloadItem{
-			HRef:   "csv-downloads-link-3",
 			Public: "csv-public-downloads-link-3",
 			Size:   "34mb",
 		},
@@ -198,7 +246,7 @@ var expectedDownloadItems = []struct {
 }{
 	{
 		csv: models.DownloadItem{
-			HRef:    "csv-downloads-link-2",
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID2 + ".csv",
 			Private: "csv-private-downloads-link-2",
 			Public:  "csv-public-downloads-link",
 			Size:    "24mb",
@@ -206,7 +254,7 @@ var expectedDownloadItems = []struct {
 	},
 	{
 		csv: models.DownloadItem{
-			HRef:    "csv-downloads-link-3",
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID3 + ".csv",
 			Private: "csv-private-downloads-link",
 			Public:  "csv-public-downloads-link-3",
 			Size:    "34mb",
@@ -214,7 +262,7 @@ var expectedDownloadItems = []struct {
 	},
 	{
 		csv: models.DownloadItem{
-			HRef:    "csv-downloads-link",
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
 			Private: "csv-private-downloads-link",
 			Public:  "csv-public-downloads-link-4",
 			Size:    "12mb",
@@ -222,7 +270,7 @@ var expectedDownloadItems = []struct {
 	},
 	{
 		xls: models.DownloadItem{
-			HRef:    "xls-downloads-link-2",
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID2 + ".xlsx",
 			Private: "xls-private-downloads-link-2",
 			Public:  "xls-public-downloads-link",
 			Size:    "34mb",
@@ -230,7 +278,7 @@ var expectedDownloadItems = []struct {
 	},
 	{
 		xls: models.DownloadItem{
-			HRef:    "xls-downloads-link-3",
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID3 + ".xlsx",
 			Private: "xls-private-downloads-link",
 			Public:  "xls-public-downloads-link-3",
 			Size:    "44mb",
@@ -238,7 +286,7 @@ var expectedDownloadItems = []struct {
 	},
 	{
 		xls: models.DownloadItem{
-			HRef:    "xls-downloads-link",
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".xlsx",
 			Private: "xls-private-downloads-link",
 			Public:  "xls-public-downloads-link-4",
 			Size:    "24mb",

--- a/cmd/dp-filter-api/main.go
+++ b/cmd/dp-filter-api/main.go
@@ -94,7 +94,8 @@ func main() {
 		apiErrors,
 		datasetAPI,
 		&previewDatasets,
-		cfg.EnablePrivateEndpoints)
+		cfg.EnablePrivateEndpoints,
+		cfg.DownloadServiceURL)
 
 	// Gracefully shutdown the application closing any open resources.
 	gracefulShutdown := func() {

--- a/config/config.go
+++ b/config/config.go
@@ -20,9 +20,10 @@ type Config struct {
 	Neo4jPoolSize              int           `envconfig:"NEO4J_POOL_SIZE"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	MongoConfig                MongoConfig
-	ServiceAuthToken           string `envconfig:"SERVICE_AUTH_TOKEN"          json:"-"`
-	ZebedeeURL                 string `envconfig:"ZEBEDEE_URL"`
-	EnablePrivateEndpoints     bool   `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
+	ServiceAuthToken           string        `envconfig:"SERVICE_AUTH_TOKEN"          json:"-"`
+	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
+	EnablePrivateEndpoints     bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
+	DownloadServiceURL         string        `envconfig:"DOWNLOAD_SERVICE_URL"`
 }
 
 // MongoConfig contains the config required to connect to MongoDB.
@@ -62,6 +63,7 @@ func Get() (*Config, error) {
 		ServiceAuthToken:       "FD0108EA-825D-411C-9B1D-41EF7727F465",
 		ZebedeeURL:             "http://localhost:8082",
 		EnablePrivateEndpoints: false,
+		DownloadServiceURL:     "http://localhost:23600",
 	}
 
 	err := envconfig.Process("", cfg)

--- a/mocks/datastore.go
+++ b/mocks/datastore.go
@@ -31,6 +31,7 @@ type DataStore struct {
 	ChangeInstanceRequest  bool
 	InvalidDimensionOption bool
 	Unpublished            bool
+	MissingPublicLinks     bool
 }
 
 // AddFilter represents the mocked version of creating a filter blueprint to the datastore
@@ -153,10 +154,29 @@ func (ds *DataStore) GetFilterOutput(filterID string) (*models.Filter, error) {
 
 	if ds.Unpublished {
 		return &models.Filter{InstanceID: "12345678", FilterID: filterID, State: "created", Dimensions: []models.Dimension{{Name: "time"}}, Links: models.LinkMap{FilterBlueprint: models.LinkObject{ID: filterID}}}, nil
-
 	}
 
-	return &models.Filter{InstanceID: "12345678", FilterID: filterID, Published: true, State: "created", Dimensions: []models.Dimension{{Name: "time"}}}, nil
+	downloads := &models.Downloads{
+		CSV: &models.DownloadItem{
+			HRef:    "ons-test-site.gov.uk/87654321.csv",
+			Private: "csv-private-link",
+			Size:    "12mb",
+		},
+		XLS: &models.DownloadItem{
+			HRef:    "ons-test-site.gov.uk/87654321.xls",
+			Private: "xls-private-link",
+			Size:    "24mb",
+		},
+	}
+
+	if ds.MissingPublicLinks {
+		return &models.Filter{InstanceID: "12345678", FilterID: filterID, Published: true, State: "completed", Dimensions: []models.Dimension{{Name: "time"}}, Downloads: downloads}, nil
+	}
+
+	downloads.CSV.Public = "csv-public-link"
+	downloads.XLS.Public = "xls-public-link"
+
+	return &models.Filter{InstanceID: "12345678", FilterID: filterID, Published: true, State: "completed", Dimensions: []models.Dimension{{Name: "time"}}, Downloads: downloads}, nil
 }
 
 // RemoveFilterDimension represents the mocked version of removing a filter dimension from the datastore

--- a/mocks/datastore.go
+++ b/mocks/datastore.go
@@ -107,18 +107,18 @@ func (ds *DataStore) GetFilter(filterID string) (*models.Filter, error) {
 	}
 
 	if ds.ChangeInstanceRequest {
-		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Published: true, Dimensions: []models.Dimension{{Name: "age", Options: []string{"33"}}}}, nil
+		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Published: &models.Published, Dimensions: []models.Dimension{{Name: "age", Options: []string{"33"}}}}, nil
 	}
 
 	if ds.InvalidDimensionOption {
-		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Published: true, Dimensions: []models.Dimension{{Name: "age", Options: []string{"28"}}}}, nil
+		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Published: &models.Published, Dimensions: []models.Dimension{{Name: "age", Options: []string{"28"}}}}, nil
 	}
 
 	if ds.Unpublished {
 		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Dimensions: []models.Dimension{{Name: "time", Options: []string{"2014", "2015"}}}}, nil
 	}
 
-	return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Published: true, Dimensions: []models.Dimension{{Name: "time", Options: []string{"2014", "2015"}}}}, nil
+	return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Published: &models.Published, Dimensions: []models.Dimension{{Name: "time", Options: []string{"2014", "2015"}}}}, nil
 }
 
 // GetFilterDimension represents the mocked version of getting a filter dimension from the datastore
@@ -149,7 +149,7 @@ func (ds *DataStore) GetFilterOutput(filterID string) (*models.Filter, error) {
 	}
 
 	if ds.BadRequest {
-		return &models.Filter{InstanceID: "12345678", FilterID: filterID, Published: true, State: "created"}, nil
+		return &models.Filter{InstanceID: "12345678", FilterID: filterID, Published: &models.Published, State: "created"}, nil
 	}
 
 	if ds.Unpublished {
@@ -170,13 +170,13 @@ func (ds *DataStore) GetFilterOutput(filterID string) (*models.Filter, error) {
 	}
 
 	if ds.MissingPublicLinks {
-		return &models.Filter{InstanceID: "12345678", FilterID: filterID, Published: true, State: "completed", Dimensions: []models.Dimension{{Name: "time"}}, Downloads: downloads}, nil
+		return &models.Filter{InstanceID: "12345678", FilterID: filterID, Published: &models.Published, State: "completed", Dimensions: []models.Dimension{{Name: "time"}}, Downloads: downloads}, nil
 	}
 
 	downloads.CSV.Public = "csv-public-link"
 	downloads.XLS.Public = "xls-public-link"
 
-	return &models.Filter{InstanceID: "12345678", FilterID: filterID, Published: true, State: "completed", Dimensions: []models.Dimension{{Name: "time"}}, Downloads: downloads}, nil
+	return &models.Filter{InstanceID: "12345678", FilterID: filterID, Published: &models.Published, State: "completed", Dimensions: []models.Dimension{{Name: "time"}}, Downloads: downloads}, nil
 }
 
 // RemoveFilterDimension represents the mocked version of removing a filter dimension from the datastore

--- a/models/models.go
+++ b/models/models.go
@@ -43,7 +43,7 @@ type Filter struct {
 	Events      Events      `bson:"events,omitempty"     json:"events,omitempty"`
 	FilterID    string      `bson:"filter_id"            json:"filter_id,omitempty"`
 	State       string      `bson:"state,omitempty"      json:"state,omitempty"`
-	Published   *bool       `bson:"published"            json:"published"`
+	Published   *bool       `bson:"published,omitempty"  json:"published,omitempty"`
 	Links       LinkMap     `bson:"links"                json:"links,omitempty"`
 	LastUpdated time.Time   `bson:"last_updated"         json:"-"`
 }

--- a/models/models.go
+++ b/models/models.go
@@ -16,6 +16,11 @@ const (
 	CompletedState = "completed"
 )
 
+var (
+	Unpublished = false
+	Published   = true
+)
+
 // Dataset contains the uniique identifiers that make a dataset unique
 type Dataset struct {
 	ID      string `bson:"id"        json:"id"`
@@ -38,7 +43,7 @@ type Filter struct {
 	Events      Events      `bson:"events,omitempty"     json:"events,omitempty"`
 	FilterID    string      `bson:"filter_id"            json:"filter_id,omitempty"`
 	State       string      `bson:"state,omitempty"      json:"state,omitempty"`
-	Published   bool        `bson:"published,omitempty"  json:"-"`
+	Published   *bool       `bson:"published"            json:"published"`
 	Links       LinkMap     `bson:"links"                json:"links,omitempty"`
 	LastUpdated time.Time   `bson:"last_updated"         json:"-"`
 }
@@ -230,7 +235,7 @@ func (filter *Filter) ValidateFilterOutputUpdate(currentFilter *Filter) error {
 		forbiddenFields = append(forbiddenFields, "filter_id")
 	}
 
-	if currentFilter.Published && currentFilter.Downloads != nil {
+	if currentFilter.Published != nil && currentFilter.Published == &Published && currentFilter.Downloads != nil {
 		if filter.Downloads != nil {
 			if filter.Downloads.CSV != nil {
 				// If version for filter output is published and filter output has a

--- a/models/models.go
+++ b/models/models.go
@@ -67,15 +67,16 @@ type Dimension struct {
 
 // Downloads represents a list of file types possible to download
 type Downloads struct {
-	CSV  DownloadItem `bson:"csv"  json:"csv"`
-	JSON DownloadItem `bson:"json" json:"json"`
-	XLS  DownloadItem `bson:"xls"  json:"xls"`
+	CSV *DownloadItem `bson:"csv,omitempty"  json:"csv,omitempty"`
+	XLS *DownloadItem `bson:"xls,omitempty"  json:"xls,omitempty"`
 }
 
 // DownloadItem represents an object containing information for the download item
 type DownloadItem struct {
-	Size string `bson:"size,omitempty" json:"size"`
-	URL  string `bson:"url,omitempty"  json:"url"`
+	HRef    string `bson:"href,omitempty"    json:"href,omitempty"`
+	Private string `bson:"private,omitempty" json:"private,omitempty"`
+	Public  string `bson:"public,omitempty"  json:"public,omitempty"`
+	Size    string `bson:"size,omitempty"    json:"size,omitempty"`
 }
 
 // Events represents a list of array objects containing event information against the filter job
@@ -196,7 +197,7 @@ func ValidateFilterDimensionOptions(filterDimensionOptions []string, datasetDime
 }
 
 // ValidateFilterOutputUpdate checks the content of the filter structure
-func (filter *Filter) ValidateFilterOutputUpdate() error {
+func (filter *Filter) ValidateFilterOutputUpdate(currentFilter *Filter) error {
 
 	// Only downloads, events and state can be updated, any attempt to update other
 	// fields will result in an error of forbidden
@@ -227,6 +228,42 @@ func (filter *Filter) ValidateFilterOutputUpdate() error {
 
 	if filter.FilterID != "" {
 		forbiddenFields = append(forbiddenFields, "filter_id")
+	}
+
+	if currentFilter.Published && currentFilter.Downloads != nil {
+		if filter.Downloads != nil {
+			if filter.Downloads.CSV != nil {
+				// If version for filter output is published and filter output has a
+				// public link, do not allow any updates to download item (csv)
+				var hasCSVPublicDownload bool
+				if currentFilter.Downloads.CSV != nil && currentFilter.Downloads.CSV.Public != "" {
+					hasCSVPublicDownload = true
+					forbiddenFields = append(forbiddenFields, "downloads.csv")
+				}
+
+				// If version for filter output is published, do not allow updates to create
+				// csv private link unless there are no downloads
+				if !hasCSVPublicDownload && filter.Downloads.CSV.Private != "" {
+					forbiddenFields = append(forbiddenFields, "downloads.csv.private")
+				}
+			}
+
+			if filter.Downloads.XLS != nil {
+				// If version for filter output is published and filter output has a
+				// public link, do not allow any updates to download item (xls)
+				var hasXLSPublicDownload bool
+				if currentFilter.Downloads.XLS != nil && currentFilter.Downloads.XLS.Public != "" {
+					hasXLSPublicDownload = true
+					forbiddenFields = append(forbiddenFields, "downloads.xls")
+				}
+
+				// If version for filter output is published, do not allow updates to create
+				// xls private link unless there are no downloads
+				if !hasXLSPublicDownload && filter.Downloads.XLS.Private != "" {
+					forbiddenFields = append(forbiddenFields, "downloads.xls.private")
+				}
+			}
+		}
 	}
 
 	if forbiddenFields != nil {

--- a/models/models.go
+++ b/models/models.go
@@ -235,13 +235,13 @@ func (filter *Filter) ValidateFilterOutputUpdate(currentFilter *Filter) error {
 		forbiddenFields = append(forbiddenFields, "filter_id")
 	}
 
-	if currentFilter.Published != nil && currentFilter.Published == &Published && currentFilter.Downloads != nil {
+	if currentFilter.Published != nil && *currentFilter.Published == Published && currentFilter.Downloads != nil {
 		if filter.Downloads != nil {
-			if filter.Downloads.CSV != nil {
+			if filter.Downloads.CSV != nil && currentFilter.Downloads.CSV != nil {
 				// If version for filter output is published and filter output has a
 				// public link, do not allow any updates to download item (csv)
 				var hasCSVPublicDownload bool
-				if currentFilter.Downloads.CSV != nil && currentFilter.Downloads.CSV.Public != "" {
+				if currentFilter.Downloads.CSV.Public != "" {
 					hasCSVPublicDownload = true
 					forbiddenFields = append(forbiddenFields, "downloads.csv")
 				}
@@ -253,11 +253,12 @@ func (filter *Filter) ValidateFilterOutputUpdate(currentFilter *Filter) error {
 				}
 			}
 
-			if filter.Downloads.XLS != nil {
+			if filter.Downloads.XLS != nil && currentFilter.Downloads.XLS != nil {
+
 				// If version for filter output is published and filter output has a
 				// public link, do not allow any updates to download item (xls)
 				var hasXLSPublicDownload bool
-				if currentFilter.Downloads.XLS != nil && currentFilter.Downloads.XLS.Public != "" {
+				if currentFilter.Downloads.XLS.Public != "" {
 					hasXLSPublicDownload = true
 					forbiddenFields = append(forbiddenFields, "downloads.xls")
 				}

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -82,7 +82,7 @@ func TestValidateFilterOutputUpdate(t *testing.T) {
 		filter, err := CreateFilter(reader)
 		So(err, ShouldBeNil)
 
-		currentFilter := &Filter{Published: false}
+		currentFilter := &Filter{Published: &Unpublished}
 
 		Convey("When filter is validated then no errors are returned", func() {
 
@@ -96,7 +96,7 @@ func TestValidateFilterOutputUpdate(t *testing.T) {
 		filter, err := CreateFilter(reader)
 		So(err, ShouldBeNil)
 
-		currentFilter := &Filter{Published: false}
+		currentFilter := &Filter{Published: &Unpublished}
 
 		Convey("When filter is validated then an error is returned", func() {
 
@@ -111,7 +111,7 @@ func TestValidateFilterOutputUpdate(t *testing.T) {
 		filter, err := CreateFilter(reader)
 		So(err, ShouldBeNil)
 
-		currentFilter := &Filter{Published: false}
+		currentFilter := &Filter{Published: &Unpublished}
 
 		Convey("When filter is validated then an error is returned", func() {
 
@@ -126,7 +126,7 @@ func TestValidateFilterOutputUpdate(t *testing.T) {
 		filter, err := CreateFilter(reader)
 		So(err, ShouldBeNil)
 
-		currentFilter := &Filter{Published: false}
+		currentFilter := &Filter{Published: &Unpublished}
 
 		Convey("When filter is validated then an error is returned", func() {
 
@@ -141,7 +141,7 @@ func TestValidateFilterOutputUpdate(t *testing.T) {
 		filter, err := CreateFilter(reader)
 		So(err, ShouldBeNil)
 
-		currentFilter := &Filter{Published: false}
+		currentFilter := &Filter{Published: &Unpublished}
 
 		Convey("When filter is validated then an error is returned", func() {
 
@@ -167,7 +167,8 @@ func TestValidateFilterOutputDownloadsUpdate(t *testing.T) {
 				Size:    "24mb",
 			},
 		}
-		currentFilter := &Filter{Published: true, Downloads: downloads}
+
+		currentFilter := &Filter{Published: &Published, Downloads: downloads}
 
 		Convey("When filter update contains csv private link", func() {
 			reader := strings.NewReader(`{"downloads":{"csv":{"href":"some-test-url","size":"12mb","private":"some-private-link"}}}`)
@@ -243,7 +244,7 @@ func TestValidateFilterOutputDownloadsUpdate(t *testing.T) {
 				Size:    "24mb",
 			},
 		}
-		currentFilter := &Filter{Published: true, Downloads: downloads}
+		currentFilter := &Filter{Published: &Published, Downloads: downloads}
 
 		Convey("When filter update contains csv public link", func() {
 			reader := strings.NewReader(`{"downloads":{"csv":{"href":"some-test-url","size":"12mb","public":"some-public-link"}}}`)

--- a/mongo/filterstore.go
+++ b/mongo/filterstore.go
@@ -283,16 +283,16 @@ func createUpdateFilterOutput(filter *models.Filter, currentTime time.Time) bson
 	state := models.CreatedState
 	var update bson.M
 	if filter.Downloads != nil {
-		if filter.Downloads.XLS.URL != "" {
-			downloads.XLS = filter.Downloads.XLS
+		if filter.Downloads.XLS != nil {
+			if filter.Downloads.XLS.HRef != "" {
+				downloads.XLS = filter.Downloads.XLS
+			}
 		}
 
-		if filter.Downloads.CSV.URL != "" {
-			downloads.CSV = filter.Downloads.CSV
-		}
-
-		if filter.Downloads.JSON.URL != "" {
-			downloads.JSON = filter.Downloads.JSON
+		if filter.Downloads.CSV != nil {
+			if filter.Downloads.CSV.HRef != "" {
+				downloads.CSV = filter.Downloads.CSV
+			}
 		}
 	}
 
@@ -301,7 +301,7 @@ func createUpdateFilterOutput(filter *models.Filter, currentTime time.Time) bson
 	}
 
 	// Don't bother checking for JSON as it doesn't get generated at the moment
-	if downloads.CSV.URL != "" && downloads.XLS.URL != "" {
+	if downloads.CSV != nil && downloads.CSV.HRef != "" && downloads.XLS != nil && downloads.XLS.HRef != "" {
 		update = bson.M{
 			"$set": bson.M{
 				"downloads": downloads,

--- a/mongo/filterstore_test.go
+++ b/mongo/filterstore_test.go
@@ -13,8 +13,8 @@ func TestCreateUpdateFilterOutput(t *testing.T) {
 	Convey("When a filter output is updated with a new CSV file", t, func() {
 		filterOutput := models.Filter{
 			Downloads: &models.Downloads{
-				CSV: models.DownloadItem{
-					URL:  "http://dataset-bucket/123.csv",
+				CSV: &models.DownloadItem{
+					HRef: "http://dataset-bucket/123.csv",
 					Size: "321",
 				},
 			},
@@ -22,7 +22,7 @@ func TestCreateUpdateFilterOutput(t *testing.T) {
 		data := createUpdateFilterOutput(&filterOutput, time.Now())
 		Convey("Then the returned bson object contains the latest changes", func() {
 			downloads := data["$set"].(bson.M)["downloads"].(models.Downloads)
-			So(downloads.CSV.URL, ShouldEndWith, filterOutput.Downloads.CSV.URL)
+			So(downloads.CSV.HRef, ShouldEndWith, filterOutput.Downloads.CSV.HRef)
 			So(downloads.CSV.Size, ShouldEndWith, filterOutput.Downloads.CSV.Size)
 		})
 	})
@@ -30,8 +30,8 @@ func TestCreateUpdateFilterOutput(t *testing.T) {
 	Convey("When a filter output is updated with a new XLSX file", t, func() {
 		filterOutput := models.Filter{
 			Downloads: &models.Downloads{
-				XLS: models.DownloadItem{
-					URL:  "http://dataset-bucket/123.xlsx",
+				XLS: &models.DownloadItem{
+					HRef: "http://dataset-bucket/123.xlsx",
 					Size: "3213",
 				},
 			},
@@ -39,7 +39,7 @@ func TestCreateUpdateFilterOutput(t *testing.T) {
 		data := createUpdateFilterOutput(&filterOutput, time.Now())
 		Convey("Then the returned bson object contains the latest changes", func() {
 			downloads := data["$set"].(bson.M)["downloads"].(models.Downloads)
-			So(downloads.XLS.URL, ShouldEndWith, filterOutput.Downloads.XLS.URL)
+			So(downloads.XLS.HRef, ShouldEndWith, filterOutput.Downloads.XLS.HRef)
 			So(downloads.XLS.Size, ShouldEndWith, filterOutput.Downloads.XLS.Size)
 		})
 	})
@@ -47,12 +47,12 @@ func TestCreateUpdateFilterOutput(t *testing.T) {
 	Convey("When a filter output is updated with both a XLSX and CSV file", t, func() {
 		filterOutput := models.Filter{
 			Downloads: &models.Downloads{
-				XLS: models.DownloadItem{
-					URL:  "http://dataset-bucket/123.xlsx",
+				XLS: &models.DownloadItem{
+					HRef: "http://dataset-bucket/123.xlsx",
 					Size: "3213",
 				},
-				CSV: models.DownloadItem{
-					URL:  "http://dataset-bucket/123.csv",
+				CSV: &models.DownloadItem{
+					HRef: "http://dataset-bucket/123.csv",
 					Size: "321",
 				},
 			},
@@ -61,9 +61,9 @@ func TestCreateUpdateFilterOutput(t *testing.T) {
 		Convey("Then the returned bson object contains the latest changes", func() {
 			state := data["$set"].(bson.M)["state"].(string)
 			downloads := data["$set"].(bson.M)["downloads"].(models.Downloads)
-			So(downloads.XLS.URL, ShouldEndWith, filterOutput.Downloads.XLS.URL)
+			So(downloads.XLS.HRef, ShouldEndWith, filterOutput.Downloads.XLS.HRef)
 			So(downloads.XLS.Size, ShouldEndWith, filterOutput.Downloads.XLS.Size)
-			So(downloads.CSV.URL, ShouldEndWith, filterOutput.Downloads.CSV.URL)
+			So(downloads.CSV.HRef, ShouldEndWith, filterOutput.Downloads.CSV.HRef)
 			So(downloads.CSV.Size, ShouldEndWith, filterOutput.Downloads.CSV.Size)
 			So(state, ShouldEqual, models.CompletedState)
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -527,8 +527,6 @@ definitions:
     properties:
       xls:
         $ref: '#/definitions/DownloadFile'
-      json:
-        $ref: '#/definitions/DownloadFile'
       csv:
         $ref: '#/definitions/DownloadFile'
   Option:
@@ -579,12 +577,18 @@ definitions:
   DownloadFile:
     type: object
     properties:
-      url:
+      href:
         type: string
         description: "The URL to the generated file"
       size:
         type: string
         description: "The size of the file in bytes"
+      public:
+        type: string
+        description: "The URL to a public-accessible download"
+      private:
+        type: string
+        description: "The URL to a non public-accessible download"
   FilterLinks:
     description: "A list of links related to this resource"
     readOnly: true


### PR DESCRIPTION
### What

Update filterOutput resource with private and public links (incl. specs)

Also includes:
* updating GetFilterOutputs endpoint to hide private links if
 user is not authorised
* updating PutFilterOutputs endpoint to prevent updates to downloads
 object when the public link already exists and the version is
 published

Unit tests updated and extended for both validation and api tests

### How to review

Check changes made make logical sense and unit tests pass as well as the filterAPI acceptance tests on branch `feature/filter-private-public-links`, e2e tests will fail as this feature needs several other services to be merged into cmd-develop as well as PR's on the `dp-api-tests` repo.

### Who can review

Team B
