### PR TITLE
Default to publishing 'mode' via config instead of makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ BIN_DIR?=.
 export GOOS?=$(shell go env GOOS)
 export GOARCH?=$(shell go env GOARCH)
 
-export ENABLE_PRIVATE_ENDPOINTS=true
-
 build:
 	@mkdir -p $(BUILD_ARCH)/$(BIN_DIR)
 	go build -o $(BUILD_ARCH)/$(BIN_DIR)/dp-filter-api cmd/$(MAIN)/main.go

--- a/config/config.go
+++ b/config/config.go
@@ -62,7 +62,7 @@ func Get() (*Config, error) {
 		},
 		ServiceAuthToken:       "FD0108EA-825D-411C-9B1D-41EF7727F465",
 		ZebedeeURL:             "http://localhost:8082",
-		EnablePrivateEndpoints: false,
+		EnablePrivateEndpoints: true,
 		DownloadServiceURL:     "http://localhost:23600",
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,6 +33,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.MongoConfig.OutputsCollection, ShouldEqual, "filterOutputs")
 				So(cfg.ServiceAuthToken, ShouldEqual, "FD0108EA-825D-411C-9B1D-41EF7727F465")
 				So(cfg.ZebedeeURL, ShouldEqual, "http://localhost:8082")
+				So(cfg.EnablePrivateEndpoints, ShouldEqual, true)
 			})
 		})
 	})


### PR DESCRIPTION
Default to publishing 'mode' via config instead of makefile
Allowing it to be overridden


