### PR TITLE
Ensure filter output state is set as its current value

### DIFF
--- a/api/filter_outputs.go
+++ b/api/filter_outputs.go
@@ -164,6 +164,8 @@ func (api *FilterAPI) updateFilterOutput(ctx context.Context, filterOutputID str
 
 	buildDownloadsObject(previousFilterOutput, filterOutput, api.downloadServiceURL)
 
+	filterOutput.State = previousFilterOutput.State
+
 	isNowStatusCompleted := false
 	if downloadsAreGenerated(filterOutput) {
 		log.InfoCtx(ctx, "downloads have been generated, setting filter output status to completed", logData)


### PR DESCRIPTION
### What

Ensure filter output state is set as its current value. This was previously defaulting to `created` in the mongo package. Now that its been refactored out of there it was not being defaulted, and hence it was an empty string. There is a conditional further on in the code that checks for a created state. This was failing due to the empty value.

### How to review

Review changes

### Who can review

Anyone
