### PR TITLE
Add 'skipped' to download items and complete filter output if skipped

### DIFF
--- a/api/filter_outputs.go
+++ b/api/filter_outputs.go
@@ -12,13 +12,14 @@ import (
 
 	"context"
 
+	"io/ioutil"
+	"time"
+
 	"github.com/ONSdigital/dp-filter-api/filters"
 	"github.com/ONSdigital/dp-filter-api/preview"
 	"github.com/ONSdigital/go-ns/common"
 	"github.com/ONSdigital/go-ns/request"
 	"github.com/pkg/errors"
-	"io/ioutil"
-	"time"
 )
 
 var (
@@ -207,9 +208,11 @@ func downloadsAreGenerated(filterOutput *models.Filter) bool {
 		// if all downloads are complete then set the filter state to complete
 		if filterOutput.Downloads != nil &&
 			filterOutput.Downloads.CSV != nil &&
-			filterOutput.Downloads.CSV.HRef != "" &&
+			(filterOutput.Downloads.CSV.HRef != "" ||
+				filterOutput.Downloads.CSV.Skipped) &&
 			filterOutput.Downloads.XLS != nil &&
-			filterOutput.Downloads.XLS.HRef != "" {
+			(filterOutput.Downloads.XLS.HRef != "" ||
+				filterOutput.Downloads.XLS.Skipped) {
 			return true
 		}
 	}
@@ -381,7 +384,7 @@ func buildDownloadsObject(previousFilterOutput, filterOutput *models.Filter, dow
 		return
 	}
 
-	if filterOutput.Downloads.CSV != nil {
+	if filterOutput.Downloads.CSV != nil && !filterOutput.Downloads.CSV.Skipped {
 
 		filterOutput.Downloads.CSV.HRef = downloadServiceURL + "/downloads/filter-outputs/" + previousFilterOutput.FilterID + ".csv"
 
@@ -403,7 +406,7 @@ func buildDownloadsObject(previousFilterOutput, filterOutput *models.Filter, dow
 		}
 	}
 
-	if filterOutput.Downloads.XLS != nil {
+	if filterOutput.Downloads.XLS != nil && !filterOutput.Downloads.XLS.Skipped {
 
 		filterOutput.Downloads.XLS.HRef = downloadServiceURL + "/downloads/filter-outputs/" + previousFilterOutput.FilterID + ".xlsx"
 

--- a/api/filter_outputs_download_test.go
+++ b/api/filter_outputs_download_test.go
@@ -1,0 +1,302 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/ONSdigital/dp-filter-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var testOptions = []struct {
+	inputPreviousFilterOutput *models.Filter
+	inputFilterOutput         *models.Filter
+	expectedOutput            *models.Filter
+	title                     string
+}{
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: nil},
+		inputFilterOutput:         &models.Filter{Downloads: &fullDownloads},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
+		title:                     "no previous downloads, providing full downloads",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &fullDownloads},
+		inputFilterOutput:         &models.Filter{Downloads: nil},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
+		title:                     "existing downloads, providing empty update",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: nil},
+		inputFilterOutput:         &models.Filter{Downloads: &csvDownloadsOnly},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: csvFullDownload}},
+		title:                     "no previous downloads, providing only csv",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: nil},
+		inputFilterOutput:         &models.Filter{Downloads: &xlsDownloadsOnly},
+		expectedOutput:            &models.Filter{Downloads: &xlsDownloadsOnlyOutputs},
+		title:                     "no previous downloads, providing only xls",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
+		title:                     "existing csv download, providing xls",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
+		title:                     "existing xls download, providing csv",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID2, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[1].csv}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[0].csv}},
+		title:                     "existing csv download, providing private csv link",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID3, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[2].csv}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[1].csv}},
+		title:                     "existing csv download, provding public csv link",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[3].csv}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[2].csv}},
+		title:                     "existing csv download, providing public xls link but no size",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID2, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[1].xls}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[3].xls}},
+		title:                     "existing xls download, providing private xls link",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID3, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[2].xls}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[4].xls}},
+		title:                     "existing xls download, providing public xls link",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[3].xls}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[5].xls}},
+		title:                     "existing xls download, providing public xls link but no size",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{CSV: &csvScenario[0].csv, XLS: &xlsScenario[0].xls}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[3].csv, XLS: &xlsScenario[3].xls}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[2].csv, XLS: &expectedDownloadItems[5].xls}},
+		title:                     "existing downloads, providing update links for both but no sizes",
+	},
+	{
+		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
+		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[4].xls}},
+		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv, XLS: nil}},
+		title:                     "existing csv download, skipped xls generation",
+	},
+}
+
+func TestBuildDownloadsObject(t *testing.T) {
+
+	Convey("Successfully build download object", t, func() {
+
+		for _, option := range testOptions {
+			Convey(option.title, func() {
+				buildDownloadsObject(option.inputPreviousFilterOutput, option.inputFilterOutput, downloadServiceURL)
+				So(option.inputFilterOutput, ShouldResemble, option.expectedOutput)
+			})
+		}
+	})
+}
+
+// Test data
+var (
+	fullDownloads = models.Downloads{
+		CSV: &models.DownloadItem{
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link",
+			Size:    "12mb",
+		},
+		XLS: &models.DownloadItem{
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link",
+			Size:    "24mb",
+		},
+	}
+
+	csvDownloadsOnly = models.Downloads{
+		CSV: &models.DownloadItem{
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link",
+			Size:    "12mb",
+		},
+		XLS: nil,
+	}
+
+	xlsDownloadsOnly = models.Downloads{
+		XLS: &models.DownloadItem{
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link",
+			Size:    "24mb",
+		},
+		CSV: nil,
+	}
+
+	fullDownloadsOutputs = models.Downloads{
+		CSV: &models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link",
+			Size:    "12mb",
+		},
+		XLS: &models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".xlsx",
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link",
+			Size:    "24mb",
+		},
+	}
+
+	csvFullDownload = &models.DownloadItem{
+		HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
+		Private: "csv-private-downloads-link",
+		Public:  "csv-public-downloads-link",
+		Size:    "12mb",
+	}
+
+	xlsDownloadsOnlyOutputs = models.Downloads{
+		XLS: &models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".xlsx",
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link",
+			Size:    "24mb",
+		},
+		CSV: nil,
+	}
+)
+
+var xlsScenario = []struct {
+	xls models.DownloadItem
+}{
+	{
+		xls: models.DownloadItem{
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link",
+			Size:    "24mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			Private: "xls-private-downloads-link-2",
+			Size:    "34mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			Public: "xls-public-downloads-link-3",
+			Size:   "44mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			Public: "xls-public-downloads-link-4",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			Skipped: true,
+		},
+	},
+}
+
+var csvScenario = []struct {
+	csv models.DownloadItem
+}{
+	{
+		csv: models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link",
+			Size:    "12mb",
+		},
+	},
+	{
+		csv: models.DownloadItem{
+			Private: "csv-private-downloads-link-2",
+			Size:    "24mb",
+		},
+	},
+	{
+		csv: models.DownloadItem{
+			Public: "csv-public-downloads-link-3",
+			Size:   "34mb",
+		},
+	},
+	{
+		csv: models.DownloadItem{
+			Public: "csv-public-downloads-link-4",
+		},
+	},
+	{
+		csv: models.DownloadItem{
+			Skipped: true,
+		},
+	},
+}
+
+var expectedDownloadItems = []struct {
+	csv models.DownloadItem
+	xls models.DownloadItem
+}{
+	{
+		csv: models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID2 + ".csv",
+			Private: "csv-private-downloads-link-2",
+			Public:  "csv-public-downloads-link",
+			Size:    "24mb",
+		},
+	},
+	{
+		csv: models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID3 + ".csv",
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link-3",
+			Size:    "34mb",
+		},
+	},
+	{
+		csv: models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
+			Private: "csv-private-downloads-link",
+			Public:  "csv-public-downloads-link-4",
+			Size:    "12mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID2 + ".xlsx",
+			Private: "xls-private-downloads-link-2",
+			Public:  "xls-public-downloads-link",
+			Size:    "34mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID3 + ".xlsx",
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link-3",
+			Size:    "44mb",
+		},
+	},
+	{
+		xls: models.DownloadItem{
+			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".xlsx",
+			Private: "xls-private-downloads-link",
+			Public:  "xls-public-downloads-link-4",
+			Size:    "24mb",
+		},
+	},
+}

--- a/api/filter_outputs_test.go
+++ b/api/filter_outputs_test.go
@@ -28,287 +28,6 @@ const (
 	filterID3 = "123"
 )
 
-var testOptions = []struct {
-	inputPreviousFilterOutput *models.Filter
-	inputFilterOutput         *models.Filter
-	expectedOutput            *models.Filter
-	title                     string
-}{
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: nil},
-		inputFilterOutput:         &models.Filter{Downloads: &fullDownloads},
-		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
-		title:                     "1",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &fullDownloads},
-		inputFilterOutput:         &models.Filter{Downloads: nil},
-		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
-		title:                     "2",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: nil},
-		inputFilterOutput:         &models.Filter{Downloads: &csvDownloadsOnly},
-		expectedOutput:            &models.Filter{Downloads: &csvDownloadsOnlyOutputs},
-		title:                     "3",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: nil},
-		inputFilterOutput:         &models.Filter{Downloads: &xlsDownloadsOnly},
-		expectedOutput:            &models.Filter{Downloads: &xlsDownloadsOnlyOutputs},
-		title:                     "4",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
-		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
-		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
-		title:                     "5",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
-		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
-		expectedOutput:            &models.Filter{Downloads: &fullDownloadsOutputs},
-		title:                     "6",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID2, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
-		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[1].csv}},
-		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[0].csv}},
-		title:                     "7",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID3, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
-		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[2].csv}},
-		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[1].csv}},
-		title:                     "8",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{CSV: &csvScenario[0].csv}},
-		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[3].csv}},
-		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[2].csv}},
-		title:                     "9",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID2, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
-		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[1].xls}},
-		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[3].xls}},
-		title:                     "10",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID3, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
-		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[2].xls}},
-		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[4].xls}},
-		title:                     "11",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{XLS: &xlsScenario[0].xls}},
-		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{XLS: &xlsScenario[3].xls}},
-		expectedOutput:            &models.Filter{Downloads: &models.Downloads{XLS: &expectedDownloadItems[5].xls}},
-		title:                     "12",
-	},
-	{
-		inputPreviousFilterOutput: &models.Filter{FilterID: filterID1, Downloads: &models.Downloads{CSV: &csvScenario[0].csv, XLS: &xlsScenario[0].xls}},
-		inputFilterOutput:         &models.Filter{Downloads: &models.Downloads{CSV: &csvScenario[3].csv, XLS: &xlsScenario[3].xls}},
-		expectedOutput:            &models.Filter{Downloads: &models.Downloads{CSV: &expectedDownloadItems[2].csv, XLS: &expectedDownloadItems[5].xls}},
-		title:                     "13",
-	},
-}
-
-func TestBuildDownloadsObject(t *testing.T) {
-
-	Convey("Successfully build download object", t, func() {
-
-		for _, option := range testOptions {
-			Convey(option.title, func() {
-				buildDownloadsObject(option.inputPreviousFilterOutput, option.inputFilterOutput, downloadServiceURL)
-				So(option.inputFilterOutput, ShouldResemble, option.expectedOutput)
-			})
-		}
-	})
-}
-
-// Test data
-var (
-	fullDownloads = models.Downloads{
-		CSV: &models.DownloadItem{
-			Private: "csv-private-downloads-link",
-			Public:  "csv-public-downloads-link",
-			Size:    "12mb",
-		},
-		XLS: &models.DownloadItem{
-			Private: "xls-private-downloads-link",
-			Public:  "xls-public-downloads-link",
-			Size:    "24mb",
-		},
-	}
-
-	csvDownloadsOnly = models.Downloads{
-		CSV: &models.DownloadItem{
-			Private: "csv-private-downloads-link",
-			Public:  "csv-public-downloads-link",
-			Size:    "12mb",
-		},
-		XLS: nil,
-	}
-
-	xlsDownloadsOnly = models.Downloads{
-		XLS: &models.DownloadItem{
-			Private: "xls-private-downloads-link",
-			Public:  "xls-public-downloads-link",
-			Size:    "24mb",
-		},
-		CSV: nil,
-	}
-
-	fullDownloadsOutputs = models.Downloads{
-		CSV: &models.DownloadItem{
-			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
-			Private: "csv-private-downloads-link",
-			Public:  "csv-public-downloads-link",
-			Size:    "12mb",
-		},
-		XLS: &models.DownloadItem{
-			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".xlsx",
-			Private: "xls-private-downloads-link",
-			Public:  "xls-public-downloads-link",
-			Size:    "24mb",
-		},
-	}
-
-	csvDownloadsOnlyOutputs = models.Downloads{
-		CSV: &models.DownloadItem{
-			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
-			Private: "csv-private-downloads-link",
-			Public:  "csv-public-downloads-link",
-			Size:    "12mb",
-		},
-		XLS: nil,
-	}
-
-	xlsDownloadsOnlyOutputs = models.Downloads{
-		XLS: &models.DownloadItem{
-			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".xlsx",
-			Private: "xls-private-downloads-link",
-			Public:  "xls-public-downloads-link",
-			Size:    "24mb",
-		},
-		CSV: nil,
-	}
-)
-
-var xlsScenario = []struct {
-	xls models.DownloadItem
-}{
-	{
-		xls: models.DownloadItem{
-			Private: "xls-private-downloads-link",
-			Public:  "xls-public-downloads-link",
-			Size:    "24mb",
-		},
-	},
-	{
-		xls: models.DownloadItem{
-			Private: "xls-private-downloads-link-2",
-			Size:    "34mb",
-		},
-	},
-	{
-		xls: models.DownloadItem{
-			Public: "xls-public-downloads-link-3",
-			Size:   "44mb",
-		},
-	},
-	{
-		xls: models.DownloadItem{
-			Public: "xls-public-downloads-link-4",
-		},
-	},
-}
-
-var csvScenario = []struct {
-	csv models.DownloadItem
-}{
-	{
-		csv: models.DownloadItem{
-			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
-			Private: "csv-private-downloads-link",
-			Public:  "csv-public-downloads-link",
-			Size:    "12mb",
-		},
-	},
-	{
-		csv: models.DownloadItem{
-			Private: "csv-private-downloads-link-2",
-			Size:    "24mb",
-		},
-	},
-	{
-		csv: models.DownloadItem{
-			Public: "csv-public-downloads-link-3",
-			Size:   "34mb",
-		},
-	},
-	{
-		csv: models.DownloadItem{
-			Public: "csv-public-downloads-link-4",
-		},
-	},
-}
-
-var expectedDownloadItems = []struct {
-	csv models.DownloadItem
-	xls models.DownloadItem
-}{
-	{
-		csv: models.DownloadItem{
-			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID2 + ".csv",
-			Private: "csv-private-downloads-link-2",
-			Public:  "csv-public-downloads-link",
-			Size:    "24mb",
-		},
-	},
-	{
-		csv: models.DownloadItem{
-			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID3 + ".csv",
-			Private: "csv-private-downloads-link",
-			Public:  "csv-public-downloads-link-3",
-			Size:    "34mb",
-		},
-	},
-	{
-		csv: models.DownloadItem{
-			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".csv",
-			Private: "csv-private-downloads-link",
-			Public:  "csv-public-downloads-link-4",
-			Size:    "12mb",
-		},
-	},
-	{
-		xls: models.DownloadItem{
-			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID2 + ".xlsx",
-			Private: "xls-private-downloads-link-2",
-			Public:  "xls-public-downloads-link",
-			Size:    "34mb",
-		},
-	},
-	{
-		xls: models.DownloadItem{
-			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID3 + ".xlsx",
-			Private: "xls-private-downloads-link",
-			Public:  "xls-public-downloads-link-3",
-			Size:    "44mb",
-		},
-	},
-	{
-		xls: models.DownloadItem{
-			HRef:    downloadServiceURL + "/downloads/filter-outputs/" + filterID1 + ".xlsx",
-			Private: "xls-private-downloads-link",
-			Public:  "xls-public-downloads-link-4",
-			Size:    "24mb",
-		},
-	},
-}
-
 func TestSuccessfulGetFilterOutput(t *testing.T) {
 	t.Parallel()
 
@@ -608,6 +327,41 @@ func TestSuccessfulUpdateFilterOutput_StatusComplete(t *testing.T) {
 		Convey("When the PUT filter output endpoint is called with completed download data", func() {
 
 			reader := strings.NewReader(`{"downloads":{"csv":{"size":"12mb", "public":"s3-public-csv-location"}, "xls":{"size":"12mb", "public":"s3-public-xls-location"}}}`)
+			r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
+
+			w := httptest.NewRecorder()
+			api.router.ServeHTTP(w, r)
+
+			Convey("Then the auditor is called for the attempt and outcome", func() {
+				assertAuditCalled(mockAuditor, updateFilterOutputAction, actionSuccessful, expectedAuditParams)
+			})
+
+			Convey("Then the data store is called to update the event", func() {
+				So(len(mockDatastore.UpdateFilterOutputCalls()), ShouldEqual, 1)
+				filterOutput := mockDatastore.UpdateFilterOutputCalls()[0].FilterOutput
+				So(filterOutput.State, ShouldEqual, models.CompletedState)
+			})
+
+			Convey("Then the data store is called to add a completed event", func() {
+				So(len(mockDatastore.AddEventToFilterOutputCalls()), ShouldEqual, 1)
+				filterOutput := mockDatastore.AddEventToFilterOutputCalls()[0]
+				So(filterOutput.Event.Type, ShouldEqual, eventFilterOutputCompleted)
+			})
+
+			Convey("Then the response code should be 200 OK", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+			})
+
+			Convey("Then the request body has been drained", func() {
+				bytesRead, err := r.Body.Read(make([]byte, 1))
+				So(bytesRead, ShouldEqual, 0)
+				So(err, ShouldEqual, io.EOF)
+			})
+		})
+
+		Convey("When the PUT filter output endpoint is called with completed csv but skipped xls download data", func() {
+
+			reader := strings.NewReader(`{"downloads":{"csv":{"size":"12mb", "public":"s3-public-csv-location"}, "xls":{"skipped":true}}}`)
 			r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 			w := httptest.NewRecorder()

--- a/models/models.go
+++ b/models/models.go
@@ -109,6 +109,7 @@ type Downloads struct {
 
 // DownloadItem represents an object containing information for the download item
 type DownloadItem struct {
+	Skipped bool   `bson:"skipped,omitempty json:skipped,omitempty"`
 	HRef    string `bson:"href,omitempty"    json:"href,omitempty"`
 	Private string `bson:"private,omitempty" json:"private,omitempty"`
 	Public  string `bson:"public,omitempty"  json:"public,omitempty"`

--- a/models/models.go
+++ b/models/models.go
@@ -109,7 +109,7 @@ type Downloads struct {
 
 // DownloadItem represents an object containing information for the download item
 type DownloadItem struct {
-	Skipped bool   `bson:"skipped,omitempty json:skipped,omitempty"`
+	Skipped bool   `bson:"skipped,omitempty" json:"skipped,omitempty"`
 	HRef    string `bson:"href,omitempty"    json:"href,omitempty"`
 	Private string `bson:"private,omitempty" json:"private,omitempty"`
 	Public  string `bson:"public,omitempty"  json:"public,omitempty"`


### PR DESCRIPTION
### What

Add 'skipped' flag to download items
Allow filters to be marked 'complete' when an output has been marked as skipped

### How to review

goes with:
https://github.com/ONSdigital/dp-dataset-exporter/pull/58
https://github.com/ONSdigital/dp-dataset-exporter-xlsx/pull/76

test setting skipped flags marks outputs as complete

### Who can review

anyone