### PR TITLE
Update completed logic to only write event once

### DIFF
--- a/api/filter_outputs.go
+++ b/api/filter_outputs.go
@@ -204,7 +204,7 @@ func (api *FilterAPI) updateFilterOutput(ctx context.Context, filterOutputID str
 
 func downloadsAreGenerated(filterOutput *models.Filter) bool {
 	if filterOutput.State == models.CompletedState {
-		return true
+		return false
 	}
 
 	// if all downloads are complete then set the filter state to complete


### PR DESCRIPTION
### What

revert recent logic change to only return true on requests that require a change of state, rather than requests where the state is already completed

### How to review

check FilterOutputComplete event is only created once for each output

### Who can review

anyone