### PR TITLE
Prevent app closure on startup

### DIFF
--- a/cmd/dp-filter-api/main.go
+++ b/cmd/dp-filter-api/main.go
@@ -11,9 +11,8 @@ import (
 	"github.com/ONSdigital/dp-filter-api/api"
 	"github.com/ONSdigital/dp-filter-api/config"
 	"github.com/ONSdigital/dp-filter-api/filterOutputQueue"
-	"github.com/ONSdigital/dp-filter-api/mongo"
+	"github.com/ONSdigital/dp-filter-api/initialise"
 	"github.com/ONSdigital/dp-filter-api/preview"
-	"github.com/ONSdigital/dp-graph/graph"
 	"github.com/ONSdigital/go-ns/audit"
 	"github.com/ONSdigital/go-ns/clients/dataset"
 	"github.com/ONSdigital/go-ns/healthcheck"
@@ -30,39 +29,31 @@ func main() {
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
 	cfg, err := config.Get()
-	if err != nil {
-		log.Error(err, nil)
-		os.Exit(1)
-	}
+	exitIfError(err, "unable to retrieve configuration")
 
-	// sensitive fields are omitted from config.String().
+	// sensitive fields are omitted from config.String()
 	log.Info("loaded config", log.Data{
 		"config": cfg,
 	})
 
 	envMax, err := strconv.ParseInt(cfg.KafkaMaxBytes, 10, 32)
-	if err != nil {
-		log.ErrorC("encountered error parsing kafka max bytes", err, nil)
-		os.Exit(1)
-	}
+	exitIfError(err, "encountered error parsing kafka max bytes")
 
-	dataStore, err := mongo.CreateFilterStore(cfg.MongoConfig, cfg.Host)
-	if err != nil {
-		log.ErrorC("could not connect to mongodb", err, nil)
-		os.Exit(1)
-	}
+	var serviceList initialise.ExternalServiceList
 
-	observationStore, err := graph.New(context.Background(), graph.Subsets{Observation: true})
-	if err != nil {
-		log.ErrorC("could not connect to graph", err, nil)
-		os.Exit(1)
-	}
+	dataStore, err := serviceList.GetFilterStore(cfg)
+	logIfError(err, "could not connect to mongodb")
 
-	producer, err := kafka.NewProducer(cfg.Brokers, cfg.FilterOutputSubmittedTopic, int(envMax))
-	if err != nil {
-		log.ErrorC("Create kafka producer error", err, nil)
-		os.Exit(1)
-	}
+	observationStore, err := serviceList.GetObservationStore()
+	logIfError(err, "could not connect to graph")
+
+	producer, err := serviceList.GetProducer(
+		cfg.Brokers,
+		cfg.FilterOutputSubmittedTopic,
+		initialise.FilterOutputSubmittedProducer,
+		int(envMax),
+	)
+	logIfError(err, "error creating kafka filter output submitted producer")
 
 	var auditor audit.AuditorService
 	var auditProducer kafka.Producer
@@ -70,11 +61,13 @@ func main() {
 	if cfg.EnablePrivateEndpoints {
 		log.Info("private endpoints enabled, enabling auditing", nil)
 
-		auditProducer, err = kafka.NewProducer(cfg.Brokers, cfg.AuditEventsTopic, 0)
-		if err != nil {
-			log.ErrorC("error creating kafka audit producer", err, nil)
-			os.Exit(1)
-		}
+		auditProducer, err = serviceList.GetProducer(
+			cfg.Brokers,
+			cfg.AuditEventsTopic,
+			initialise.AuditProducer,
+			0,
+		)
+		logIfError(err, "error creating kafka audit producer")
 
 		auditor = audit.New(auditProducer, "dp-filter-api")
 	} else {
@@ -111,55 +104,69 @@ func main() {
 		auditor,
 	)
 
+	// block until a fatal error occurs
+	select {
+	case err := <-producer.Errors():
+		log.ErrorC("kafka producer error received", err, nil)
+	case err := <-apiErrors:
+		log.ErrorC("api error received", err, nil)
+	case <-signals:
+		log.Info("os signal received", nil)
+	}
+
+	log.Info(fmt.Sprintf("Shutdown with timeout: %s", cfg.ShutdownTimeout), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
+
 	// Gracefully shutdown the application closing any open resources.
-	gracefulShutdown := func() {
-		log.Info(fmt.Sprintf("Shutdown with timeout: %s", cfg.ShutdownTimeout), nil)
-		ctx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
+	go func() {
+		defer cancel()
 
 		if err = api.Close(ctx); err != nil {
-			log.Error(err, nil)
+			logIfError(err, "unable to close api server")
 		}
 
 		healthTicker.Close()
 
-		// mongo.Close() may use all remaining time in the context
-		if err = mongolib.Close(ctx, dataStore.Session); err != nil {
-			log.Error(err, nil)
+		if serviceList.FilterStore {
+			log.Info("closing filter store", nil)
+			// mongo.Close() may use all remaining time in the context
+			logIfError(mongolib.Close(ctx, dataStore.Session), "unable to close filter store")
 		}
 
-		if err = observationStore.Close(ctx); err != nil {
-			log.Error(err, nil)
+		if serviceList.ObservationStore {
+			log.Info("closing observation store", nil)
+			logIfError(observationStore.Close(ctx), "unable to close observation store")
 		}
 
-		// Close producer after http server has closed so if a message
-		// needs to be sent to kafka off a request it can
-		if err := producer.Close(ctx); err != nil {
-			log.Error(err, nil)
+		if serviceList.FilterOutputSubmittedProducer {
+			log.Info("closing filter output submitted producer", nil)
+			// Close producer after http server has closed so if a message
+			// needs to be sent to kafka off a request it can
+			logIfError(producer.Close(ctx), "unable to close filter output submitted producer")
 		}
 
-		if cfg.EnablePrivateEndpoints {
-			log.Debug("exiting audit producer", nil)
-			if err = auditProducer.Close(ctx); err != nil {
-				log.Error(err, nil)
-			}
+		if serviceList.AuditProducer {
+			log.Info("closing audit producer", nil)
+			logIfError(auditProducer.Close(ctx), "unable to close audit producer")
 		}
+	}()
 
-		cancel()
-		log.Info("Shutdown complete", nil)
+	// wait for shutdown success (via cancel) or failure (timeout)
+	<-ctx.Done()
+
+	log.Info("Shutdown complete", nil)
+	os.Exit(1)
+}
+
+func exitIfError(err error, message string) {
+	if err != nil {
+		log.ErrorC(message, err, nil)
 		os.Exit(1)
 	}
+}
 
-	for {
-		select {
-		case err := <-producer.Errors():
-			log.ErrorC("kafka producer error received", err, nil)
-			gracefulShutdown()
-		case err := <-apiErrors:
-			log.ErrorC("api error received", err, nil)
-			gracefulShutdown()
-		case <-signals:
-			log.Debug("os signal received", nil)
-			gracefulShutdown()
-		}
+func logIfError(err error, message string) {
+	if err != nil {
+		log.ErrorC(message, err, nil)
 	}
 }

--- a/initialise/initialise.go
+++ b/initialise/initialise.go
@@ -1,0 +1,62 @@
+package initialise
+
+import (
+	"context"
+
+	"github.com/ONSdigital/dp-filter-api/config"
+	"github.com/ONSdigital/dp-filter-api/mongo"
+	"github.com/ONSdigital/dp-graph/graph"
+	"github.com/ONSdigital/go-ns/kafka"
+)
+
+// ExternalServiceList represents a list of services
+type ExternalServiceList struct {
+	AuditProducer                 bool
+	FilterOutputSubmittedProducer bool
+	FilterStore                   bool
+	ObservationStore              bool
+}
+
+const (
+	// AuditProducer represents a name for
+	// the producer that writes to an audit topic
+	AuditProducer = "audit-producer"
+	// FilterOutputSubmittedProducer represents a name for
+	// the producer that writes to a filter output submitted topic
+	FilterOutputSubmittedProducer = "filter-output-submitted-producer"
+)
+
+// GetFilterStore returns an initialised connection to filter store (mongo database)
+func (e *ExternalServiceList) GetFilterStore(cfg *config.Config) (dataStore *mongo.FilterStore, err error) {
+	dataStore, err = mongo.CreateFilterStore(cfg.MongoConfig, cfg.Host)
+	if err == nil {
+		e.FilterStore = true
+	}
+
+	return
+}
+
+// GetObservationStore returns an initialised connection to observation store (graph database)
+func (e *ExternalServiceList) GetObservationStore() (observationStore *graph.DB, err error) {
+	observationStore, err = graph.New(context.Background(), graph.Subsets{Observation: true})
+	if err == nil {
+		e.ObservationStore = true
+	}
+
+	return
+}
+
+// GetProducer returns a kafka producer
+func (e *ExternalServiceList) GetProducer(kafkaBrokers []string, topic, name string, envMax int) (kafkaProducer kafka.Producer, err error) {
+	kafkaProducer, err = kafka.NewProducer(kafkaBrokers, topic, envMax)
+	if err == nil {
+		switch {
+		case name == AuditProducer:
+			e.AuditProducer = true
+		case name == FilterOutputSubmittedProducer:
+			e.FilterOutputSubmittedProducer = true
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
### What

Prevent application falling over on start up due to external services not being available. Also remove call to gracefully shutdown when the service loses connections to other internal or external services; it should only shutdown due to the platform running application informs the service to close using system a call to interrupt or terminate the application.

### How to review

- Check service does not shutdown on startup if an external service (e.g. kafka) is not available (running)
- Check service does not call graceful shutdown if an external service (again easy to use kafka) becomes unavailable
- Check system call for termination and interrupt force a graceful shutdown
- Check unit tests pass

### Who can review

Anyone
