### PR TITLE
Fix call to graceful shutdown when api or kafka error is received

### DIFF
--- a/cmd/dp-filter-api/main.go
+++ b/cmd/dp-filter-api/main.go
@@ -104,12 +104,19 @@ func main() {
 		auditor,
 	)
 
+	go func() {
+		select {
+		case err := <-producer.Errors():
+			log.ErrorC("kafka producer error received", err, nil)
+		case err := <-auditProducer.Errors():
+			log.ErrorC("kafka audit producer error received", err, nil)
+		case err := <-apiErrors:
+			log.ErrorC("api error received", err, nil)
+		}
+	}()
+
 	// block until a fatal error occurs
 	select {
-	case err := <-producer.Errors():
-		log.ErrorC("kafka producer error received", err, nil)
-	case err := <-apiErrors:
-		log.ErrorC("api error received", err, nil)
 	case <-signals:
 		log.Info("os signal received", nil)
 	}


### PR DESCRIPTION
### What

Prevent service shutting down when the service receives an api or kafka error after it previously successfully started up.

Switch statement that allows graceful shutdown to run blocks until an os signal (interrupt or terminate) is received.

### How to review

Check app does not shutdown early, setup:

1) Start app up (make sure all external service dependencies are running)
2) Once app has been confirmed to be healthy, terminate kafka
3) Send a request to build a filter blueprint, the app should not exit as it is unable to write messages to kafka topic
4) Instead an error should be logged

Check unit tests pass

### Who can review

Anyone
