### PR TITLE
Fix/conflict on multiple patch

### DIFF
--- a/api/filter_dimension_options.go
+++ b/api/filter_dimension_options.go
@@ -212,16 +212,8 @@ func (api *FilterAPI) addFilterBlueprintDimensionOptionHandler(w http.ResponseWr
 	}
 	ctx := r.Context()
 
-	// request filterBlueprint before updating it
-	filterBlueprint, err := api.getFilterBlueprint(ctx, filterBlueprintID)
-	if err != nil {
-		log.Event(ctx, "error getting filter blueprint dimension option", log.ERROR, log.Error(err), logData)
-		setErrorCodeFromErrorExpectDimension(w, err)
-		return
-	}
-
-	// add the dimension options if not presentan dimension and options are valid
-	err = api.addFilterBlueprintDimensionOptions(ctx, filterBlueprint, dimensionName, []string{option}, logData)
+	// add the dimension options, if valid
+	err := api.addFilterBlueprintDimensionOptions(ctx, filterBlueprintID, dimensionName, []string{option}, logData)
 	if err != nil {
 		log.Event(ctx, "error adding filter blueprint dimension option", log.ERROR, log.Error(err), logData)
 		setErrorCodeFromErrorExpectDimension(w, err)
@@ -229,7 +221,7 @@ func (api *FilterAPI) addFilterBlueprintDimensionOptionHandler(w http.ResponseWr
 	}
 
 	// request filterBlueprint again in order to construct the response from the updated filter (if a new option was added)
-	filterBlueprint, err = api.getFilterBlueprint(ctx, filterBlueprintID)
+	filterBlueprint, err := api.getFilterBlueprint(ctx, filterBlueprintID)
 	if err != nil {
 		log.Event(ctx, "error getting filter blueprint dimension option after the dimension option has been successfully added", log.ERROR, log.Error(err), logData)
 		setErrorCodeFromErrorExpectDimension(w, err)
@@ -263,9 +255,14 @@ func (api *FilterAPI) addFilterBlueprintDimensionOptionHandler(w http.ResponseWr
 	log.Event(ctx, "created new dimension option for filter blueprint", log.INFO, logData)
 }
 
-func (api *FilterAPI) addFilterBlueprintDimensionOptions(ctx context.Context, filterBlueprint *models.Filter, dimensionName string, options []string, logData log.Data) error {
+// addFilterBlueprintDimensionOptions adds the provided options to the filter dimension, only if the options are available for the dimension.
+func (api *FilterAPI) addFilterBlueprintDimensionOptions(ctx context.Context, filterBlueprintID string, dimensionName string, options []string, logData log.Data) error {
 
-	timestamp := filterBlueprint.UniqueTimestamp
+	// request filterBlueprint before updating it
+	filterBlueprint, err := api.getFilterBlueprint(ctx, filterBlueprintID)
+	if err != nil {
+		return err
+	}
 
 	// Check if dimension exists and any provided option already exists
 	hasDimension, _, missingOptions := findDimensionAndOptions(filterBlueprint, dimensionName, options)
@@ -291,7 +288,7 @@ func (api *FilterAPI) addFilterBlueprintDimensionOptions(ctx context.Context, fi
 	}
 
 	// All validations succeeded - add dimension options that do not already exist
-	return api.dataStore.AddFilterDimensionOptions(filterBlueprint.FilterID, dimensionName, createArray(missingOptions), timestamp)
+	return api.dataStore.AddFilterDimensionOptions(filterBlueprintID, dimensionName, createArray(missingOptions), filterBlueprint.UniqueTimestamp)
 }
 
 func (api *FilterAPI) removeFilterBlueprintDimensionOptionHandler(w http.ResponseWriter, r *http.Request) {
@@ -308,15 +305,7 @@ func (api *FilterAPI) removeFilterBlueprintDimensionOptionHandler(w http.Respons
 	ctx := r.Context()
 	log.Event(ctx, "remove filter blueprint dimension option", log.INFO, logData)
 
-	filterBlueprint, err := api.getFilterBlueprint(ctx, filterBlueprintID)
-	if err != nil {
-		log.Event(ctx, "error removing filter blueprint dimension option", log.ERROR, log.Error(err), logData)
-		setErrorCodeFromError(w, err)
-		return
-	}
-
-	err = api.removeFilterBlueprintDimensionOption(ctx, filterBlueprint, dimensionName, option)
-	if err != nil {
+	if err := api.removeFilterBlueprintDimensionOption(ctx, filterBlueprintID, dimensionName, option); err != nil {
 		log.Event(ctx, "error removing filter blueprint dimension option", log.ERROR, log.Error(err), logData)
 		setErrorCodeFromError(w, err)
 		return
@@ -329,7 +318,13 @@ func (api *FilterAPI) removeFilterBlueprintDimensionOptionHandler(w http.Respons
 }
 
 // removeFilterBlueprintDimensionOption removes a single dimension option, failing if the option did not exist
-func (api *FilterAPI) removeFilterBlueprintDimensionOption(ctx context.Context, filterBlueprint *models.Filter, dimensionName, option string) error {
+func (api *FilterAPI) removeFilterBlueprintDimensionOption(ctx context.Context, filterBlueprintID string, dimensionName, option string) error {
+
+	// Get filter Blueprint before updating it
+	filterBlueprint, err := api.getFilterBlueprint(ctx, filterBlueprintID)
+	if err != nil {
+		return err
+	}
 
 	// Check if dimension and option exists
 	hasDimension, hasOptions, _ := findDimensionAndOptions(filterBlueprint, dimensionName, []string{option})
@@ -350,11 +345,17 @@ func (api *FilterAPI) removeFilterBlueprintDimensionOption(ctx context.Context, 
 }
 
 // removeFilterBlueprintDimensionOption removes all provided options.
-func (api *FilterAPI) removeFilterBlueprintDimensionOptions(ctx context.Context, filterBlueprint *models.Filter, dimensionName string, options []string, logData log.Data) error {
+func (api *FilterAPI) removeFilterBlueprintDimensionOptions(ctx context.Context, filterBlueprintID string, dimensionName string, options []string, logData log.Data) error {
 
 	// check if any option has been provided
 	if len(options) == 0 {
 		return nil
+	}
+
+	// Get filter Blueprint before updating it
+	filterBlueprint, err := api.getFilterBlueprint(ctx, filterBlueprintID)
+	if err != nil {
+		return err
 	}
 
 	// Check if provided dimension and options exists in filter blueprint
@@ -377,12 +378,12 @@ func (api *FilterAPI) removeFilterBlueprintDimensionOptions(ctx context.Context,
 
 	// if none of the provided options were present, we don't need to remove anything
 	if len(optionsToRemove) == 0 {
-		log.Event(ctx, "options do not exist in the dimension, nothing to remove", log.INFO, log.Data{})
+		log.Event(ctx, "options do not exist in the dimension, nothing to remove", log.INFO)
 		return nil
 	}
 
 	// remove necessary options from DB
-	return api.dataStore.RemoveFilterDimensionOptions(filterBlueprint.FilterID, dimensionName, optionsToRemove, filterBlueprint.UniqueTimestamp)
+	return api.dataStore.RemoveFilterDimensionOptions(filterBlueprintID, dimensionName, optionsToRemove, filterBlueprint.UniqueTimestamp)
 }
 
 // Handler for a list of patch operations against the dimension options
@@ -455,33 +456,17 @@ func (api *FilterAPI) patchFilterBlueprintDimensionHandler(w http.ResponseWriter
 func (api *FilterAPI) patchFilterBlueprintDimension(ctx context.Context, filterBlueprintID string, dimensionName string, patches []dprequest.Patch, logData log.Data) (successful []dprequest.Patch, err error) {
 
 	successful = []dprequest.Patch{}
-	dimensionValidated := false
 
 	// apply patch operations sequentially, stop processing if one patch fails, and return a list of successful patches operations
 	for _, patch := range patches {
 		options := removeDuplicateAndEmptyOptions(patch.Value)
 
-		// Get filter Blueprint in all iterations to prevent conflicts due to the timestamp check in mongoDB when adding or removing values
-		filterBlueprint, err := api.getFilterBlueprint(ctx, filterBlueprintID)
-		if err != nil {
-			return successful, err
-		}
-
-		// validate dimension (only once) and return ErrDimensionNotFound if it is not available, as no patch operation can succeed
-		if !dimensionValidated {
-			hasDimension, _, _ := findDimensionAndOptions(filterBlueprint, dimensionName, []string{})
-			if !hasDimension {
-				return successful, filters.ErrDimensionNotFound
-			}
-			dimensionValidated = true
-		}
-
 		if patch.Op == dprequest.OpAdd.String() {
-			if err := api.addFilterBlueprintDimensionOptions(ctx, filterBlueprint, dimensionName, options, logData); err != nil {
+			if err := api.addFilterBlueprintDimensionOptions(ctx, filterBlueprintID, dimensionName, options, logData); err != nil {
 				return successful, err
 			}
 		} else {
-			if err := api.removeFilterBlueprintDimensionOptions(ctx, filterBlueprint, dimensionName, options, logData); err != nil {
+			if err := api.removeFilterBlueprintDimensionOptions(ctx, filterBlueprintID, dimensionName, options, logData); err != nil {
 				return successful, err
 			}
 		}

--- a/api/filter_dimension_options_test.go
+++ b/api/filter_dimension_options_test.go
@@ -30,7 +30,7 @@ func TestSuccessfulAddFilterBlueprintDimensionOption(t *testing.T) {
 		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age/options/33", nil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 	})
@@ -44,7 +44,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -57,7 +57,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -70,7 +70,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -96,7 +96,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InvalidDimensionOption(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -109,7 +109,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{ConflictRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().ConflictRequest(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusConflict)
 
@@ -135,7 +135,7 @@ func TestSuccessfulRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 	})
@@ -149,7 +149,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -162,7 +162,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -175,7 +175,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -188,7 +188,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().DimensionNotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -201,7 +201,7 @@ func TestFailedToRemoveFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{ConflictRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().ConflictRequest(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusConflict)
 
@@ -227,7 +227,7 @@ func TestSuccessfulGetFilterBlueprintDimensionOptions(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options", nil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -241,7 +241,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -254,7 +254,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -267,7 +267,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -280,7 +280,7 @@ func TestFailedToGetFilterBlueprintDimensionOptions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().DimensionNotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -306,7 +306,7 @@ func TestSuccessfulGetFilterBlueprintDimensionOption(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/time/options/2015", nil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -320,7 +320,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -333,7 +333,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -346,7 +346,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -359,7 +359,7 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InvalidDimensionOption(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -371,72 +371,120 @@ func TestFailedToGetFilterBlueprintDimensionOption(t *testing.T) {
 func TestSuccessfulPatchFilterBlueprintDimension(t *testing.T) {
 	t.Parallel()
 
-	Convey("Successfully patch dimension options, with a single valid 'add' patch operation, returns 200", t, func() {
+	Convey("Sending a single valid 'add' patch operation with 2 valid options, one already existing in the filter and one that does not exist", t, func() {
 		reader := strings.NewReader(`[
 			{"op":"add", "path": "/options/-", "value": ["27","33"]}
 		]`)
 		r, err := http.NewRequest("PATCH", "http://localhost:22100/filters/12345678/dimensions/age", reader)
 		So(err, ShouldBeNil)
 
+		ds := mocks.NewDataStore().Mock
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), ds, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
+
+		Convey("Results in a 200 OK response and the valid inexistent option being added to the database", func() {
+			So(w.Code, ShouldEqual, http.StatusOK)
+			So(ds.GetFilterCalls(), ShouldHaveLength, 1)
+			So(ds.GetFilterCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.AddFilterDimensionOptionsCalls(), ShouldHaveLength, 1)
+			So(ds.AddFilterDimensionOptionsCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.AddFilterDimensionOptionsCalls()[0].Name, ShouldEqual, "age")
+			So(ds.AddFilterDimensionOptionsCalls()[0].Options, ShouldResemble, []string{"27"})
+			So(ds.RemoveFilterDimensionOptionsCalls(), ShouldHaveLength, 0)
+		})
 	})
 
-	Convey("Successfully patch dimension options, with a single valid 'remove' patch operation, returns 200", t, func() {
+	Convey("Sending a single valid 'remove' patch operation with an existent option", t, func() {
 		reader := strings.NewReader(`[
 			{"op":"remove", "path": "/options/-", "value": ["33"]}
 		]`)
 		r, err := http.NewRequest("PATCH", "http://localhost:22100/filters/12345678/dimensions/age", reader)
 		So(err, ShouldBeNil)
 
+		ds := mocks.NewDataStore().Mock
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), ds, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
+
+		Convey("Results in a 200 OK response and the option being updated to the database", func() {
+			So(w.Code, ShouldEqual, http.StatusOK)
+			So(ds.GetFilterCalls(), ShouldHaveLength, 1)
+			So(ds.GetFilterCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.AddFilterDimensionOptionsCalls(), ShouldHaveLength, 0)
+			So(ds.RemoveFilterDimensionOptionsCalls(), ShouldHaveLength, 1)
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].Name, ShouldEqual, "age")
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].Options, ShouldResemble, []string{"33"})
+		})
 	})
 
-	Convey("Successfully patch dimension options, with a single valid 'remove' patch operation with a mix of existent and inexistent options, returns 200", t, func() {
+	Convey("Sending a single valid 'remove' patch operation with a mix of existent and inexistent options", t, func() {
 		reader := strings.NewReader(`[
-			{"op":"remove", "path": "/options/-", "value": ["33", "123456789"]}
+			{"op":"remove", "path": "/options/-", "value": ["33", "inexistent"]}
 		]`)
 		r, err := http.NewRequest("PATCH", "http://localhost:22100/filters/12345678/dimensions/age", reader)
 		So(err, ShouldBeNil)
 
+		ds := mocks.NewDataStore().Mock
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), ds, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
+
+		Convey("Results in a 200 OK response and only the existing options being updated to the database", func() {
+			So(w.Code, ShouldEqual, http.StatusOK)
+			So(ds.GetFilterCalls(), ShouldHaveLength, 1)
+			So(ds.GetFilterCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.AddFilterDimensionOptionsCalls(), ShouldHaveLength, 0)
+			So(ds.RemoveFilterDimensionOptionsCalls(), ShouldHaveLength, 1)
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].Name, ShouldEqual, "age")
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].Options, ShouldResemble, []string{"33"})
+		})
 	})
 
-	Convey("Successfully patch dimension options, with a single valid 'remove' patch operation with an inexistent option, returns 200", t, func() {
+	Convey("Sending a single valid 'remove' patch operation with an inexistent option", t, func() {
 		reader := strings.NewReader(`[
-			{"op":"remove", "path": "/options/-", "value": ["123456789"]}
+			{"op":"remove", "path": "/options/-", "value": ["inexistent"]}
 		]`)
 		r, err := http.NewRequest("PATCH", "http://localhost:22100/filters/12345678/dimensions/age", reader)
 		So(err, ShouldBeNil)
 
+		ds := mocks.NewDataStore().Mock
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), ds, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
+
+		Convey("Results in a 200 OK response and no calls to remove options from the database", func() {
+			So(w.Code, ShouldEqual, http.StatusOK)
+			So(ds.GetFilterCalls(), ShouldHaveLength, 1)
+			So(ds.GetFilterCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.AddFilterDimensionOptionsCalls(), ShouldHaveLength, 0)
+			So(ds.RemoveFilterDimensionOptionsCalls(), ShouldHaveLength, 0)
+		})
 	})
 
-	Convey("Successfully patch dimension options, with a single valid 'remove' patch operation without any option, returns 200", t, func() {
+	Convey("Sending an empty list of patch operations", t, func() {
 		reader := strings.NewReader(`[
 			{"op":"remove", "path": "/options/-", "value": []}
 		]`)
 		r, err := http.NewRequest("PATCH", "http://localhost:22100/filters/12345678/dimensions/age", reader)
 		So(err, ShouldBeNil)
 
+		ds := mocks.NewDataStore().Mock
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), ds, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
+
+		Convey("Results in a 200 OK response", func() {
+			So(w.Code, ShouldEqual, http.StatusOK)
+			So(ds.GetFilterCalls(), ShouldHaveLength, 0)
+			So(ds.AddFilterDimensionOptionsCalls(), ShouldHaveLength, 0)
+			So(ds.RemoveFilterDimensionOptionsCalls(), ShouldHaveLength, 0)
+		})
 	})
 
-	Convey("Successfully patch dimension options, with a combination of valid patch operations, returns 200", t, func() {
+	Convey("Sending a list of 2 valid patch operations", t, func() {
 		reader := strings.NewReader(`[
 			{"op":"add", "path": "/options/-", "value": ["27"]},
 			{"op":"remove", "path": "/options/-", "value": ["33"]}
@@ -444,10 +492,25 @@ func TestSuccessfulPatchFilterBlueprintDimension(t *testing.T) {
 		r, err := http.NewRequest("PATCH", "http://localhost:22100/filters/12345678/dimensions/age", reader)
 		So(err, ShouldBeNil)
 
+		ds := mocks.NewDataStore().Mock
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), ds, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
+
+		Convey("Results in a 200 OK response, and the expected calls for both operations", func() {
+			So(w.Code, ShouldEqual, http.StatusOK)
+			So(ds.GetFilterCalls(), ShouldHaveLength, 2)
+			So(ds.GetFilterCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.GetFilterCalls()[1].FilterID, ShouldEqual, "12345678")
+			So(ds.AddFilterDimensionOptionsCalls(), ShouldHaveLength, 1)
+			So(ds.AddFilterDimensionOptionsCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.AddFilterDimensionOptionsCalls()[0].Name, ShouldEqual, "age")
+			So(ds.AddFilterDimensionOptionsCalls()[0].Options, ShouldResemble, []string{"27"})
+			So(ds.RemoveFilterDimensionOptionsCalls(), ShouldHaveLength, 1)
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].Name, ShouldEqual, "age")
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].Options, ShouldResemble, []string{"33"})
+		})
 	})
 
 	Convey("Successfully patch dimension options for an unpublished filter blueprint", t, func() {
@@ -457,10 +520,25 @@ func TestSuccessfulPatchFilterBlueprintDimension(t *testing.T) {
 		]`)
 		r := createAuthenticatedRequest("PATCH", "http://localhost:22100/filters/12345678/dimensions/age", reader)
 
+		ds := mocks.NewDataStore().Unpublished().Mock
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), ds, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
+
+		Convey("Results in a 200 OK response, and the expected calls for both operations", func() {
+			So(w.Code, ShouldEqual, http.StatusOK)
+			So(ds.GetFilterCalls(), ShouldHaveLength, 2)
+			So(ds.GetFilterCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.GetFilterCalls()[1].FilterID, ShouldEqual, "12345678")
+			So(ds.AddFilterDimensionOptionsCalls(), ShouldHaveLength, 1)
+			So(ds.AddFilterDimensionOptionsCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.AddFilterDimensionOptionsCalls()[0].Name, ShouldEqual, "age")
+			So(ds.AddFilterDimensionOptionsCalls()[0].Options, ShouldResemble, []string{"27"})
+			So(ds.RemoveFilterDimensionOptionsCalls(), ShouldHaveLength, 1)
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].FilterID, ShouldEqual, "12345678")
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].Name, ShouldEqual, "age")
+			So(ds.RemoveFilterDimensionOptionsCalls()[0].Options, ShouldResemble, []string{"33"})
+		})
 	})
 }
 
@@ -509,6 +587,20 @@ func TestFailedPatchBlueprintDimension(t *testing.T) {
 		So(response, ShouldResemble, "provided path '/wrong/path' not supported. Supported paths: '/options/-'\n")
 	})
 
+	Convey("Whe a valid 'add' patch with an incorrect option for a dimension is provided, a 400 BadRequest is returned", t, func() {
+		reader := strings.NewReader(`[{"op":"add", "path": "/options/-", "value": ["wrong"]}]`)
+		r, err := http.NewRequest("PATCH", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+		response := w.Body.String()
+		So(response, ShouldResemble, "incorrect dimension options chosen: [wrong]\n")
+	})
+
 	Convey("When a valid patch with an overall sum of values higher than the maximum allowed is provided, a 400 BadRequest is returned", t, func() {
 		maxRequestOptions := 10
 		reader := strings.NewReader(`[
@@ -532,7 +624,7 @@ func TestFailedPatchBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -546,7 +638,7 @@ func TestFailedPatchBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -560,7 +652,7 @@ func TestFailedPatchBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -574,7 +666,7 @@ func TestFailedPatchBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().DimensionNotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 

--- a/api/filter_dimension_options_test.go
+++ b/api/filter_dimension_options_test.go
@@ -397,6 +397,45 @@ func TestSuccessfulPatchFilterBlueprintDimension(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
 
+	Convey("Successfully patch dimension options, with a single valid 'remove' patch operation with a mix of existent and inexistent options, returns 200", t, func() {
+		reader := strings.NewReader(`[
+			{"op":"remove", "path": "/options/-", "value": ["33", "123456789"]}
+		]`)
+		r, err := http.NewRequest("PATCH", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully patch dimension options, with a single valid 'remove' patch operation with an inexistent option, returns 200", t, func() {
+		reader := strings.NewReader(`[
+			{"op":"remove", "path": "/options/-", "value": ["123456789"]}
+		]`)
+		r, err := http.NewRequest("PATCH", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Successfully patch dimension options, with a single valid 'remove' patch operation without any option, returns 200", t, func() {
+		reader := strings.NewReader(`[
+			{"op":"remove", "path": "/options/-", "value": []}
+		]`)
+		r, err := http.NewRequest("PATCH", "http://localhost:22100/filters/12345678/dimensions/age", reader)
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, serviceAuthToken)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
 	Convey("Successfully patch dimension options, with a combination of valid patch operations, returns 200", t, func() {
 		reader := strings.NewReader(`[
 			{"op":"add", "path": "/options/-", "value": ["27"]},

--- a/api/filter_dimensions_test.go
+++ b/api/filter_dimensions_test.go
@@ -33,7 +33,7 @@ func TestSuccessfulGetFilterBlueprintDimensions(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions", nil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -47,7 +47,7 @@ func TestFailedToGetFilterBlueprintDimensions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -60,7 +60,7 @@ func TestFailedToGetFilterBlueprintDimensions(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -128,7 +128,7 @@ func TestSuccessfulAddFilterBlueprintDimension(t *testing.T) {
 		r := createAuthenticatedRequest("POST", "http://localhost:22100/filters/12345678/dimensions/age", reader)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusCreated)
 
@@ -149,7 +149,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -189,7 +189,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -209,7 +209,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -269,7 +269,7 @@ func TestFailedToAddFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{ConflictRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().ConflictRequest(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusConflict)
 
@@ -304,7 +304,7 @@ func TestSuccessfulGetFilterBlueprintDimension(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -321,7 +321,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -334,7 +334,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -347,7 +347,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -360,7 +360,7 @@ func TestFailedToGetFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().DimensionNotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -386,7 +386,7 @@ func TestSuccessfulRemoveFilterBlueprintDimension(t *testing.T) {
 		r := createAuthenticatedRequest("DELETE", "http://localhost:22100/filters/12345678/dimensions/1_age", nil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNoContent)
 	})
@@ -400,7 +400,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -413,7 +413,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -426,7 +426,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -439,7 +439,7 @@ func TestFailedToRemoveFilterBlueprintDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{DimensionNotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().DimensionNotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 	})

--- a/api/filter_outputs_test.go
+++ b/api/filter_outputs_test.go
@@ -81,7 +81,7 @@ func TestSuccessfulGetFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 	})
@@ -96,7 +96,7 @@ func TestFailedToGetFilterOutput(t *testing.T) {
 
 		w := httptest.NewRecorder()
 
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -109,7 +109,7 @@ func TestFailedToGetFilterOutput(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -122,7 +122,7 @@ func TestFailedToGetFilterOutput(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -139,7 +139,7 @@ func TestSuccessfulUpdateFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().MissingPublicLinks(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -155,7 +155,7 @@ func TestSuccessfulUpdateFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().MissingPublicLinks(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -256,7 +256,7 @@ func TestSuccessfulUpdateFilterOutputUnpublished(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -272,7 +272,7 @@ func TestSuccessfulUpdateFilterOutputUnpublished(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -292,7 +292,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -311,7 +311,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -327,7 +327,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().MissingPublicLinks(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
@@ -346,7 +346,7 @@ func TestFailedToUpdateFilterOutput(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filter-outputs/21312", reader)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{MissingPublicLinks: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().MissingPublicLinks(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusForbidden)
 
@@ -534,7 +534,7 @@ func TestSuccessfulGetPreview(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filter-outputs/21312/preview", nil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(previewMock.GetPreviewCalls()[0].Limit, ShouldEqual, 20)
@@ -565,7 +565,7 @@ func TestFailedGetPreview(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -578,7 +578,7 @@ func TestFailedGetPreview(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -609,7 +609,7 @@ func TestFailedGetPreview(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{BadRequest: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().BadRequest(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 
@@ -635,7 +635,7 @@ func TestFailedGetPreview(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 

--- a/api/filters_test.go
+++ b/api/filters_test.go
@@ -117,7 +117,8 @@ func TestSuccessfulAddFilterBlueprint_UnpublishedDataset(t *testing.T) {
 	Convey("Given an unpublished dataset", t, func() {
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		ds := mocks.NewDataStore().Unpublished().Mock
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), ds, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 
 		Convey("When a POST request is made to the filters endpoint", func() {
 
@@ -133,6 +134,7 @@ func TestSuccessfulAddFilterBlueprint_UnpublishedDataset(t *testing.T) {
 				bytesRead, err := r.Body.Read(make([]byte, 1))
 				So(bytesRead, ShouldEqual, 0)
 				So(err, ShouldEqual, io.EOF)
+				So(ds.AddFilterCalls(), ShouldHaveLength, 1)
 			})
 		})
 	})
@@ -167,7 +169,7 @@ func TestFailedToAddFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 
@@ -395,7 +397,7 @@ func TestSuccessfulGetFilterBlueprint_UnpublishedDataset(t *testing.T) {
 		r := createAuthenticatedRequest("GET", "http://localhost:22100/filters/12345678", nil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
@@ -410,7 +412,7 @@ func TestFailedToGetFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InternalError: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InternalError(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -424,7 +426,7 @@ func TestFailedToGetFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -437,7 +439,7 @@ func TestFailedToGetFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -554,7 +556,7 @@ func TestSuccessfulUpdateFilterBlueprint_UnpublishedDataset(t *testing.T) {
 		r := createAuthenticatedRequest("PUT", "http://localhost:22100/filters/21312?submitted=true", reader)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -615,7 +617,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{NotFound: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().NotFound(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -636,7 +638,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 
 		w := httptest.NewRecorder()
 
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{Unpublished: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().Unpublished(), &mocks.FilterJob{}, &mocks.DatasetAPI{Unpublished: true}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 
@@ -696,7 +698,7 @@ func TestFailedToUpdateFilterBlueprint(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		w := httptest.NewRecorder()
-		api := Setup(host, maxRequestOptions, mux.NewRouter(), &mocks.DataStore{InvalidDimensionOption: true}, &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
+		api := Setup(host, maxRequestOptions, mux.NewRouter(), mocks.NewDataStore().InvalidDimensionOption(), &mocks.FilterJob{}, &mocks.DatasetAPI{}, previewMock, enablePrivateEndpoints, downloadServiceURL, downloadServiceToken, "")
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 

--- a/mocks/datastore.go
+++ b/mocks/datastore.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/globalsign/mgo/bson"
 
+	"github.com/ONSdigital/dp-filter-api/api/datastoretest"
 	"github.com/ONSdigital/dp-filter-api/filters"
 	"github.com/ONSdigital/dp-filter-api/models"
 )
@@ -14,8 +15,8 @@ var (
 	errorInternalServer = errors.New("DataStore internal error")
 )
 
-// DataStore represents a list of error flags to set error in mocked datastore
-type DataStore struct {
+// DataStoreConfig represents a list of error flags to set error in mocked datastore
+type DataStoreConfig struct {
 	NotFound               bool
 	DimensionNotFound      bool
 	OptionNotFound         bool
@@ -30,9 +31,114 @@ type DataStore struct {
 	AgeDimension           bool
 }
 
+// DataStore holds the list of possible error flats along with the mocked datastore.
+// This struct can be used directly as a mock, as it implements the required methods,
+// or you can use the internal 'moq' Mock if you want ot validate calls, parameters etc.
+type DataStore struct {
+	Cfg  DataStoreConfig
+	Mock *datastoretest.DataStoreMock
+}
+
+// NewDataStore creates a new datastore mock with an empty config
+func NewDataStore() *DataStore {
+	ds := &DataStore{
+		Cfg: DataStoreConfig{},
+	}
+	mock := &datastoretest.DataStoreMock{
+		AddFilterFunc:                    ds.AddFilter,
+		AddFilterDimensionFunc:           ds.AddFilterDimension,
+		AddFilterDimensionOptionFunc:     ds.AddFilterDimensionOption,
+		AddFilterDimensionOptionsFunc:    ds.AddFilterDimensionOptions,
+		CreateFilterOutputFunc:           ds.CreateFilterOutput,
+		GetFilterFunc:                    ds.GetFilter,
+		GetFilterDimensionFunc:           ds.GetFilterDimension,
+		GetFilterOutputFunc:              ds.GetFilterOutput,
+		RemoveFilterDimensionFunc:        ds.RemoveFilterDimension,
+		RemoveFilterDimensionOptionFunc:  ds.RemoveFilterDimensionOption,
+		RemoveFilterDimensionOptionsFunc: ds.RemoveFilterDimensionOptions,
+		UpdateFilterFunc:                 ds.UpdateFilter,
+		UpdateFilterOutputFunc:           ds.UpdateFilterOutput,
+		AddEventToFilterOutputFunc:       ds.AddEventToFilterOutput,
+	}
+	ds.Mock = mock
+	return ds
+}
+
+// NotFound sets NotFound flag to true
+func (ds *DataStore) NotFound() *DataStore {
+	ds.Cfg.NotFound = true
+	return ds
+}
+
+// DimensionNotFound sets DimensionNotFound flag to true
+func (ds *DataStore) DimensionNotFound() *DataStore {
+	ds.Cfg.DimensionNotFound = true
+	return ds
+}
+
+// OptionNotFound sets OptionNotFound flag to true
+func (ds *DataStore) OptionNotFound() *DataStore {
+	ds.Cfg.OptionNotFound = true
+	return ds
+}
+
+// VersionNotFound sets VersionNotFound flag to true
+func (ds *DataStore) VersionNotFound() *DataStore {
+	ds.Cfg.VersionNotFound = true
+	return ds
+}
+
+// ChangeInstanceRequest sets ChangeInstanceRequest flag to true
+func (ds *DataStore) ChangeInstanceRequest() *DataStore {
+	ds.Cfg.ChangeInstanceRequest = true
+	return ds
+}
+
+// InvalidDimensionOption sets InvalidDimensionOption flag to true
+func (ds *DataStore) InvalidDimensionOption() *DataStore {
+	ds.Cfg.InvalidDimensionOption = true
+	return ds
+}
+
+// Unpublished sets Unpublished flag to true
+func (ds *DataStore) Unpublished() *DataStore {
+	ds.Cfg.Unpublished = true
+	return ds
+}
+
+// InternalError sets InternalError flag to true
+func (ds *DataStore) InternalError() *DataStore {
+	ds.Cfg.InternalError = true
+	return ds
+}
+
+// MissingPublicLinks sets MissingPublicLinks flag to true
+func (ds *DataStore) MissingPublicLinks() *DataStore {
+	ds.Cfg.MissingPublicLinks = true
+	return ds
+}
+
+// BadRequest sets BadRequest flag to true
+func (ds *DataStore) BadRequest() *DataStore {
+	ds.Cfg.BadRequest = true
+	return ds
+}
+
+// ConflictRequest sets ConflictRequest flag to true
+func (ds *DataStore) ConflictRequest() *DataStore {
+	ds.Cfg.ConflictRequest = true
+	return ds
+}
+
+// AgeDimension sets AgeDimension flag to true
+func (ds *DataStore) AgeDimension() *DataStore {
+	ds.Cfg.AgeDimension = true
+	return ds
+}
+
 // AddFilter represents the mocked version of creating a filter blueprint to the datastore
 func (ds *DataStore) AddFilter(filterJob *models.Filter) (*models.Filter, error) {
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return nil, errorInternalServer
 	}
 	return &models.Filter{InstanceID: "12345678"}, nil
@@ -40,15 +146,15 @@ func (ds *DataStore) AddFilter(filterJob *models.Filter) (*models.Filter, error)
 
 // AddFilterDimension represents the mocked version of creating a filter dimension to the datastore
 func (ds *DataStore) AddFilterDimension(filterID, name string, options []string, dimensions []models.Dimension, timestamp bson.MongoTimestamp) error {
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return errorInternalServer
 	}
 
-	if ds.NotFound {
+	if ds.Cfg.NotFound {
 		return filters.ErrFilterBlueprintNotFound
 	}
 
-	if ds.ConflictRequest {
+	if ds.Cfg.ConflictRequest {
 		return filters.ErrFilterBlueprintConflict
 	}
 
@@ -57,15 +163,15 @@ func (ds *DataStore) AddFilterDimension(filterID, name string, options []string,
 
 // AddFilterDimensionOption represents the mocked version of creating a filter dimension option to the datastore
 func (ds *DataStore) AddFilterDimensionOption(filterID, name, option string, timestamp bson.MongoTimestamp) error {
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return errorInternalServer
 	}
 
-	if ds.NotFound {
+	if ds.Cfg.NotFound {
 		return filters.ErrFilterBlueprintNotFound
 	}
 
-	if ds.ConflictRequest {
+	if ds.Cfg.ConflictRequest {
 		return filters.ErrFilterBlueprintConflict
 	}
 
@@ -74,15 +180,15 @@ func (ds *DataStore) AddFilterDimensionOption(filterID, name, option string, tim
 
 // AddFilterDimensionOptions represents the mocked version of adding a list of dimension options to the datastore
 func (ds *DataStore) AddFilterDimensionOptions(filterID, name string, options []string, timestamp bson.MongoTimestamp) error {
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return errorInternalServer
 	}
 
-	if ds.NotFound {
+	if ds.Cfg.NotFound {
 		return filters.ErrDimensionNotFound
 	}
 
-	if ds.ConflictRequest {
+	if ds.Cfg.ConflictRequest {
 		return filters.ErrFilterBlueprintConflict
 	}
 
@@ -91,7 +197,7 @@ func (ds *DataStore) AddFilterDimensionOptions(filterID, name string, options []
 
 // CreateFilterOutput represents the mocked version of creating a filter output to the datastore
 func (ds *DataStore) CreateFilterOutput(filterJob *models.Filter) error {
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return errorInternalServer
 	}
 
@@ -100,30 +206,30 @@ func (ds *DataStore) CreateFilterOutput(filterJob *models.Filter) error {
 
 // GetFilter represents the mocked version of getting a filter blueprint from the datastore
 func (ds *DataStore) GetFilter(filterID string) (*models.Filter, error) {
-	if ds.NotFound {
+	if ds.Cfg.NotFound {
 		return nil, filters.ErrFilterBlueprintNotFound
 	}
 
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return nil, errorInternalServer
 	}
 
-	if ds.BadRequest {
+	if ds.Cfg.BadRequest {
 		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678"}, nil
 	}
 
-	if ds.InvalidDimensionOption {
+	if ds.Cfg.InvalidDimensionOption {
 		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Published: &models.Published, Dimensions: []models.Dimension{{Name: "age", Options: []string{"28"}}}}, nil
 	}
 
-	if ds.Unpublished {
-		if ds.DimensionNotFound {
+	if ds.Cfg.Unpublished {
+		if ds.Cfg.DimensionNotFound {
 			return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Dimensions: []models.Dimension{{URL: "http://localhost:22100/filters/12345678/dimensions/time", Name: "time", Options: []string{"2014", "2015"}}}}, nil
 		}
 		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Dimensions: []models.Dimension{{Name: "age", Options: []string{"33"}}, {URL: "http://localhost:22100/filters/12345678/dimensions/time", Name: "time", Options: []string{"2014", "2015"}}, {URL: "http://localhost:22100/filters/12345678/dimensions/1_age", Name: "1_age", Options: []string{"2014", "2015"}}}}, nil
 	}
 
-	if ds.DimensionNotFound {
+	if ds.Cfg.DimensionNotFound {
 		return &models.Filter{Dataset: &models.Dataset{ID: "123", Edition: "2017", Version: 1}, InstanceID: "12345678", Dimensions: []models.Dimension{{URL: "http://localhost:22100/filters/12345678/dimensions/time", Name: "time", Options: []string{"2014", "2015"}}}}, nil
 	}
 
@@ -132,11 +238,11 @@ func (ds *DataStore) GetFilter(filterID string) (*models.Filter, error) {
 
 // GetFilterDimension represents the mocked version of getting a filter dimension from the datastore
 func (ds *DataStore) GetFilterDimension(filterID, name string) (*models.Dimension, error) {
-	if ds.DimensionNotFound {
+	if ds.Cfg.DimensionNotFound {
 		return nil, filters.ErrDimensionNotFound
 	}
 
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return nil, errorInternalServer
 	}
 
@@ -145,19 +251,19 @@ func (ds *DataStore) GetFilterDimension(filterID, name string) (*models.Dimensio
 
 // GetFilterOutput represents the mocked version of getting a filter output from the datastore
 func (ds *DataStore) GetFilterOutput(filterID string) (*models.Filter, error) {
-	if ds.NotFound {
+	if ds.Cfg.NotFound {
 		return nil, filters.ErrFilterOutputNotFound
 	}
 
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return nil, errorInternalServer
 	}
 
-	if ds.BadRequest {
+	if ds.Cfg.BadRequest {
 		return &models.Filter{InstanceID: "12345678", FilterID: filterID, Published: &models.Published, State: "created"}, nil
 	}
 
-	if ds.Unpublished {
+	if ds.Cfg.Unpublished {
 		return &models.Filter{InstanceID: "12345678", FilterID: filterID, State: "created", Dimensions: []models.Dimension{{Name: "time"}}, Links: models.LinkMap{FilterBlueprint: models.LinkObject{ID: filterID}}}, nil
 	}
 
@@ -174,7 +280,7 @@ func (ds *DataStore) GetFilterOutput(filterID string) (*models.Filter, error) {
 		},
 	}
 
-	if ds.MissingPublicLinks {
+	if ds.Cfg.MissingPublicLinks {
 		return &models.Filter{InstanceID: "12345678", FilterID: filterID, Published: &models.Published, State: "created", Dimensions: []models.Dimension{{Name: "time"}}, Downloads: downloads}, nil
 	}
 
@@ -186,15 +292,15 @@ func (ds *DataStore) GetFilterOutput(filterID string) (*models.Filter, error) {
 
 // RemoveFilterDimension represents the mocked version of removing a filter dimension from the datastore
 func (ds *DataStore) RemoveFilterDimension(string, string, bson.MongoTimestamp) error {
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return errorInternalServer
 	}
 
-	if ds.NotFound {
+	if ds.Cfg.NotFound {
 		return filters.ErrFilterBlueprintNotFound
 	}
 
-	if ds.ConflictRequest {
+	if ds.Cfg.ConflictRequest {
 		return filters.ErrFilterBlueprintConflict
 	}
 
@@ -203,15 +309,15 @@ func (ds *DataStore) RemoveFilterDimension(string, string, bson.MongoTimestamp) 
 
 // RemoveFilterDimensionOption represents the mocked version of removing a filter dimension option from the datastore
 func (ds *DataStore) RemoveFilterDimensionOption(filterJobID, name, option string, timestamp bson.MongoTimestamp) error {
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return errorInternalServer
 	}
 
-	if ds.DimensionNotFound {
+	if ds.Cfg.DimensionNotFound {
 		return filters.ErrDimensionNotFound
 	}
 
-	if ds.ConflictRequest {
+	if ds.Cfg.ConflictRequest {
 		return filters.ErrFilterBlueprintConflict
 	}
 
@@ -220,15 +326,15 @@ func (ds *DataStore) RemoveFilterDimensionOption(filterJobID, name, option strin
 
 // RemoveFilterDimensionOptions represents the mocked version of removing a set of filter dimension options from the datastore
 func (ds *DataStore) RemoveFilterDimensionOptions(filterJobID, name string, options []string, timestamp bson.MongoTimestamp) error {
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return errorInternalServer
 	}
 
-	if ds.NotFound {
+	if ds.Cfg.NotFound {
 		return filters.ErrDimensionNotFound
 	}
 
-	if ds.ConflictRequest {
+	if ds.Cfg.ConflictRequest {
 		return filters.ErrFilterBlueprintConflict
 	}
 
@@ -237,19 +343,19 @@ func (ds *DataStore) RemoveFilterDimensionOptions(filterJobID, name string, opti
 
 // UpdateFilter represents the mocked version of updating a filter blueprint from the datastore
 func (ds *DataStore) UpdateFilter(filterJob *models.Filter, timestamp bson.MongoTimestamp) error {
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return errorInternalServer
 	}
 
-	if ds.NotFound {
+	if ds.Cfg.NotFound {
 		return filters.ErrFilterBlueprintNotFound
 	}
 
-	if ds.VersionNotFound {
+	if ds.Cfg.VersionNotFound {
 		return filters.ErrVersionNotFound
 	}
 
-	if ds.ConflictRequest {
+	if ds.Cfg.ConflictRequest {
 		return filters.ErrFilterBlueprintConflict
 	}
 
@@ -258,15 +364,15 @@ func (ds *DataStore) UpdateFilter(filterJob *models.Filter, timestamp bson.Mongo
 
 // UpdateFilterOutput represents the mocked version of updating a filter output from the datastore
 func (ds *DataStore) UpdateFilterOutput(filterJob *models.Filter, timestamp bson.MongoTimestamp) error {
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return errorInternalServer
 	}
 
-	if ds.NotFound {
+	if ds.Cfg.NotFound {
 		return filters.ErrFilterBlueprintNotFound
 	}
 
-	if ds.ConflictRequest {
+	if ds.Cfg.ConflictRequest {
 		return filters.ErrFilterOutputConflict
 	}
 
@@ -275,11 +381,11 @@ func (ds *DataStore) UpdateFilterOutput(filterJob *models.Filter, timestamp bson
 
 // AddEventToFilterOutput adds the given event to the filter output of the given ID
 func (ds *DataStore) AddEventToFilterOutput(filterOutputID string, event *models.Event) error {
-	if ds.InternalError {
+	if ds.Cfg.InternalError {
 		return errorInternalServer
 	}
 
-	if ds.NotFound {
+	if ds.Cfg.NotFound {
 		return filters.ErrFilterOutputNotFound
 	}
 


### PR DESCRIPTION
### What

- Fixed bug where multiple patch operations could sometimes cause a 409 conflict because we were using the filter blueprint timestamp from the first time we read it. Now we read it before applying each patch.
- Fixed bug in remove options, where we were not removing options if any of the provided options did not exist. Now we verify exactly what we need to remove.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (feel free to ask me for a quick demo) it can be tested by running filter api with `make debug`, and sending the following patch operations to `http://localhost:22100/filters/{filterID}/dimensions/aggregate`:
  - sending patch with multiple operations returns 200OK :
```
[
    {
        "op": "add",
        "path": "/options/-",
        "value": ["cpih1dim1G110200"]
    },
    {
        "op": "remove",
        "path": "/options/-",
        "value": ["cpih1dim1G110200"]
    }
]
```
  - sending remove patch with existing and inexistent items results in the existing items being removed:
```
[
    {
        "op": "remove",
        "path": "/options/-",
        "value": ["cpih1dim1G110200", "inexistent"]
    }
]
```
### Who can review

Anyone