### PR TITLE
Removed code related to old /healthcheck endpoint

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -186,6 +186,9 @@ func newMiddleware(healthcheckHandler func(http.ResponseWriter, *http.Request), 
 			if req.Method == "GET" && req.URL.Path == endpoint {
 				healthcheckHandler(w, req)
 				return
+			} else if req.Method == "GET" && req.URL.Path == "/healthcheck" {
+				http.NotFound(w, req)
+				return
 			}
 			h.ServeHTTP(w, req)
 		})

--- a/service/service.go
+++ b/service/service.go
@@ -166,10 +166,8 @@ func (svc *Service) Start(ctx context.Context, svcErrors chan error) {
 // CreateMiddleware creates an Alice middleware chain of handlers
 func (svc *Service) createMiddleware(ctx context.Context) alice.Chain {
 	healthCheckHandler := newMiddleware(svc.healthCheck.Handler, "/health")
-	oldHealthCheckHandler := newMiddleware(svc.healthCheck.Handler, "/healthcheck")
 	middlewareChain := alice.New(
 		healthCheckHandler,
-		oldHealthCheckHandler,
 		dphandlers.CheckHeader(dphandlers.CollectionID))
 
 	if svc.cfg.EnablePrivateEndpoints {


### PR DESCRIPTION
### What

Removed code related to old /healthcheck endpoint, as per this ticket - https://trello.com/c/ECS9esvf/4743-filter-api-remove-transitional-health-check-code-1d

### How to review

Run service locally and confirm that /healthcheck endpoint returns a 404 error

### Who can review

Anyone
