### PR TITLE
Update dp-api-clients-go dependency to fix id query parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-filter-api
 go 1.15
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.31.2
+	github.com/ONSdigital/dp-api-clients-go v1.32.1
 	github.com/ONSdigital/dp-graph/v2 v2.3.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.31.2 h1:2ZutIrkPeUv6BmmBlVj0sjfr/kTavVAk9qIOpNEt/uQ=
-github.com/ONSdigital/dp-api-clients-go v1.31.2/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.32.1 h1:LKmld3zgouccCGW2RizLZeUIEvIfAUO8VEuPMGLau88=
+github.com/ONSdigital/dp-api-clients-go v1.32.1/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-graph/v2 v2.3.0 h1:xK9qImVbh86l04aAUeurjB7d8mwn27eacP+5gpvPLO8=
 github.com/ONSdigital/dp-graph/v2 v2.3.0/go.mod h1:K4LIhFcyxB8g7nUG5I5I8x6QVf89x82dCEFBbE0mmaQ=

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -405,9 +405,9 @@ func TestClose(t *testing.T) {
 		})
 
 		Convey("Given that a dependency takes more time to close than the graceful shutdown timeout", func() {
-			cfg.ShutdownTimeout = 1 * time.Millisecond
+			cfg.ShutdownTimeout = 5 * time.Millisecond
 			serverMock.ShutdownFunc = func(ctx context.Context) error {
-				time.Sleep(2 * time.Millisecond)
+				time.Sleep(10 * time.Millisecond)
 				return nil
 			}
 


### PR DESCRIPTION
### What

- Upgraded `dp-api-clients-go` version to fix dataset get options by list of IDs.
- Increased shutdown timeout and sleep for testing to minimize the probability of a race condition with context switching.

### How to review

- Make sure that dp-api-clients-go was upgraded to version 1.32.1
- Make sure unit tests pass

### Who can review

Anyone