### PR TITLE
use dataset GetOptionsBatchProcess for options validation by ID

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -16,7 +16,7 @@ import (
 type DatasetAPI interface {
 	GetVersion(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceAuthToken, collectionID, datasetID, edition, version string) (m dataset.Version, err error)
 	GetVersionDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version string) (m dataset.VersionDimensions, err error)
-	GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, q dataset.QueryParams) (m dataset.Options, err error)
+	GetOptionsBatchProcess(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, optionIDs *[]string, processBatch dataset.OptionsBatchProcessor, batchSize, maxWorkers int) (err error)
 }
 
 // OutputQueue - An interface used to queue filter outputs
@@ -44,6 +44,7 @@ type FilterAPI struct {
 	defaultLimit         int
 	defaultOffset        int
 	maxDatasetOptions    int
+	BatchMaxWorkers      int
 }
 
 // Setup manages all the routes configured to API
@@ -69,6 +70,7 @@ func Setup(
 		defaultLimit:         cfg.MongoConfig.Limit,
 		defaultOffset:        cfg.MongoConfig.Offset,
 		maxDatasetOptions:    cfg.MaxDatasetOptions,
+		BatchMaxWorkers:      cfg.BatchMaxWorkers,
 	}
 
 	api.router.HandleFunc("/filters", api.postFilterBlueprintHandler).Methods("POST")

--- a/api/filter_dimension_options_test.go
+++ b/api/filter_dimension_options_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-filter-api/mocks"
 	"github.com/ONSdigital/dp-filter-api/models"
 	"github.com/gorilla/mux"
@@ -34,8 +33,8 @@ func TestSuccessfulAddFilterBlueprintDimensionOption(t *testing.T) {
 
 		Convey("And the dimension and options are efficiently validated with dataset API", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls()[0].Q, ShouldResemble, dataset.QueryParams{IDs: []string{"33"}})
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 1)
+			So(*datasetAPIMock.GetOptionsBatchProcessCalls()[0].OptionIDs, ShouldResemble, []string{"33"})
 		})
 	})
 
@@ -53,8 +52,8 @@ func TestSuccessfulAddFilterBlueprintDimensionOption(t *testing.T) {
 
 		Convey("And the dimension and options are efficiently validated with dataset API", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls()[0].Q, ShouldResemble, dataset.QueryParams{IDs: []string{"33"}})
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 1)
+			So(*datasetAPIMock.GetOptionsBatchProcessCalls()[0].OptionIDs, ShouldResemble, []string{"33"})
 		})
 	})
 }
@@ -78,7 +77,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 
 		Convey("And no dimension or option is validated against DatasetAPI", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 0)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 0)
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 0)
 		})
 	})
 
@@ -98,7 +97,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 
 		Convey("And no dimension or option is validated against DatasetAPI", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 0)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 0)
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 0)
 		})
 	})
 
@@ -118,7 +117,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 
 		Convey("And no dimension or option is validated against DatasetAPI", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 0)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 0)
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 0)
 		})
 	})
 
@@ -138,8 +137,8 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 
 		Convey("And the dimension and options are efficiently validated with dataset API", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls()[0].Q, ShouldResemble, dataset.QueryParams{IDs: []string{"66"}})
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 1)
+			So(*datasetAPIMock.GetOptionsBatchProcessCalls()[0].OptionIDs, ShouldResemble, []string{"66"})
 		})
 	})
 
@@ -160,7 +159,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 
 		Convey("And no dimension or option is validated against DatasetAPI", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 0)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 0)
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 0)
 		})
 	})
 
@@ -180,7 +179,7 @@ func TestFailedToAddFilterBlueprintDimensionOption(t *testing.T) {
 
 		Convey("And no dimension or option is validated against DatasetAPI", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 0)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 0)
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 0)
 		})
 	})
 }
@@ -635,8 +634,8 @@ func TestSuccessfulPatchFilterBlueprintDimension(t *testing.T) {
 
 		Convey("And the dimension and options are efficiently validated with dataset API", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls()[0].Q, ShouldResemble, dataset.QueryParams{IDs: []string{"27", "33"}})
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 1)
+			So(*datasetAPIMock.GetOptionsBatchProcessCalls()[0].OptionIDs, ShouldResemble, []string{"27", "33"})
 		})
 
 		Convey("And only the valid inexistent option being added to the database", func() {
@@ -669,7 +668,7 @@ func TestSuccessfulPatchFilterBlueprintDimension(t *testing.T) {
 
 		Convey("And no dimension or option is validated against DatasetAPI", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 0)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 0)
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 0)
 		})
 
 		Convey("And the option being removed from the database", func() {
@@ -702,7 +701,7 @@ func TestSuccessfulPatchFilterBlueprintDimension(t *testing.T) {
 
 		Convey("And no dimension or option is validated against DatasetAPI", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 0)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 0)
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 0)
 		})
 
 		Convey("And only the existing options being updated to the database", func() {
@@ -735,7 +734,7 @@ func TestSuccessfulPatchFilterBlueprintDimension(t *testing.T) {
 
 		Convey("And no dimension or option is validated against DatasetAPI", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 0)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 0)
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 0)
 		})
 
 		Convey("And no calls to remove options from the database", func() {
@@ -765,7 +764,7 @@ func TestSuccessfulPatchFilterBlueprintDimension(t *testing.T) {
 
 		Convey("And no dimension or option is validated against DatasetAPI", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 0)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 0)
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 0)
 		})
 
 		Convey("And no calls the database", func() {
@@ -795,8 +794,8 @@ func TestSuccessfulPatchFilterBlueprintDimension(t *testing.T) {
 
 		Convey("And the dimension and options are efficiently validated with dataset API", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls()[0].Q, ShouldResemble, dataset.QueryParams{IDs: []string{"27"}})
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 1)
+			So(*datasetAPIMock.GetOptionsBatchProcessCalls()[0].OptionIDs, ShouldResemble, []string{"27"})
 		})
 
 		Convey("And the expected calls for both operations are performed against the database", func() {
@@ -833,8 +832,8 @@ func TestSuccessfulPatchFilterBlueprintDimension(t *testing.T) {
 
 		Convey("And the dimension and options are efficiently validated with dataset API", func() {
 			So(datasetAPIMock.GetVersionDimensionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls(), ShouldHaveLength, 1)
-			So(datasetAPIMock.GetOptionsCalls()[0].Q, ShouldResemble, dataset.QueryParams{IDs: []string{"27"}})
+			So(datasetAPIMock.GetOptionsBatchProcessCalls(), ShouldHaveLength, 1)
+			So(*datasetAPIMock.GetOptionsBatchProcessCalls()[0].OptionIDs, ShouldResemble, []string{"27"})
 		})
 
 		Convey("And the expected calls for both operations are performed against the database", func() {

--- a/api/mocks/datasetapi.go
+++ b/api/mocks/datasetapi.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	lockDatasetAPIMockGetOptions           sync.RWMutex
-	lockDatasetAPIMockGetVersion           sync.RWMutex
-	lockDatasetAPIMockGetVersionDimensions sync.RWMutex
+	lockDatasetAPIMockGetOptionsBatchProcess sync.RWMutex
+	lockDatasetAPIMockGetVersion             sync.RWMutex
+	lockDatasetAPIMockGetVersionDimensions   sync.RWMutex
 )
 
 // DatasetAPIMock is a mock implementation of api.DatasetAPI.
@@ -21,8 +21,8 @@ var (
 //
 //         // make and configure a mocked api.DatasetAPI
 //         mockedDatasetAPI := &DatasetAPIMock{
-//             GetOptionsFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, id string, edition string, version string, dimension string, q dataset.QueryParams) (dataset.Options, error) {
-// 	               panic("mock out the GetOptions method")
+//             GetOptionsBatchProcessFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, id string, edition string, version string, dimension string, optionIDs *[]string, processBatch dataset.OptionsBatchProcessor, batchSize int, maxWorkers int) error {
+// 	               panic("mock out the GetOptionsBatchProcess method")
 //             },
 //             GetVersionFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, downloadServiceAuthToken string, collectionID string, datasetID string, edition string, version string) (dataset.Version, error) {
 // 	               panic("mock out the GetVersion method")
@@ -37,8 +37,8 @@ var (
 //
 //     }
 type DatasetAPIMock struct {
-	// GetOptionsFunc mocks the GetOptions method.
-	GetOptionsFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, id string, edition string, version string, dimension string, q dataset.QueryParams) (dataset.Options, error)
+	// GetOptionsBatchProcessFunc mocks the GetOptionsBatchProcess method.
+	GetOptionsBatchProcessFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, id string, edition string, version string, dimension string, optionIDs *[]string, processBatch dataset.OptionsBatchProcessor, batchSize int, maxWorkers int) error
 
 	// GetVersionFunc mocks the GetVersion method.
 	GetVersionFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, downloadServiceAuthToken string, collectionID string, datasetID string, edition string, version string) (dataset.Version, error)
@@ -48,8 +48,8 @@ type DatasetAPIMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// GetOptions holds details about calls to the GetOptions method.
-		GetOptions []struct {
+		// GetOptionsBatchProcess holds details about calls to the GetOptionsBatchProcess method.
+		GetOptionsBatchProcess []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// UserAuthToken is the userAuthToken argument value.
@@ -66,8 +66,14 @@ type DatasetAPIMock struct {
 			Version string
 			// Dimension is the dimension argument value.
 			Dimension string
-			// Q is the q argument value.
-			Q dataset.QueryParams
+			// OptionIDs is the optionIDs argument value.
+			OptionIDs *[]string
+			// ProcessBatch is the processBatch argument value.
+			ProcessBatch dataset.OptionsBatchProcessor
+			// BatchSize is the batchSize argument value.
+			BatchSize int
+			// MaxWorkers is the maxWorkers argument value.
+			MaxWorkers int
 		}
 		// GetVersion holds details about calls to the GetVersion method.
 		GetVersion []struct {
@@ -108,10 +114,10 @@ type DatasetAPIMock struct {
 	}
 }
 
-// GetOptions calls GetOptionsFunc.
-func (mock *DatasetAPIMock) GetOptions(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, id string, edition string, version string, dimension string, q dataset.QueryParams) (dataset.Options, error) {
-	if mock.GetOptionsFunc == nil {
-		panic("DatasetAPIMock.GetOptionsFunc: method is nil but DatasetAPI.GetOptions was just called")
+// GetOptionsBatchProcess calls GetOptionsBatchProcessFunc.
+func (mock *DatasetAPIMock) GetOptionsBatchProcess(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, id string, edition string, version string, dimension string, optionIDs *[]string, processBatch dataset.OptionsBatchProcessor, batchSize int, maxWorkers int) error {
+	if mock.GetOptionsBatchProcessFunc == nil {
+		panic("DatasetAPIMock.GetOptionsBatchProcessFunc: method is nil but DatasetAPI.GetOptionsBatchProcess was just called")
 	}
 	callInfo := struct {
 		Ctx              context.Context
@@ -122,7 +128,10 @@ func (mock *DatasetAPIMock) GetOptions(ctx context.Context, userAuthToken string
 		Edition          string
 		Version          string
 		Dimension        string
-		Q                dataset.QueryParams
+		OptionIDs        *[]string
+		ProcessBatch     dataset.OptionsBatchProcessor
+		BatchSize        int
+		MaxWorkers       int
 	}{
 		Ctx:              ctx,
 		UserAuthToken:    userAuthToken,
@@ -132,18 +141,21 @@ func (mock *DatasetAPIMock) GetOptions(ctx context.Context, userAuthToken string
 		Edition:          edition,
 		Version:          version,
 		Dimension:        dimension,
-		Q:                q,
+		OptionIDs:        optionIDs,
+		ProcessBatch:     processBatch,
+		BatchSize:        batchSize,
+		MaxWorkers:       maxWorkers,
 	}
-	lockDatasetAPIMockGetOptions.Lock()
-	mock.calls.GetOptions = append(mock.calls.GetOptions, callInfo)
-	lockDatasetAPIMockGetOptions.Unlock()
-	return mock.GetOptionsFunc(ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, q)
+	lockDatasetAPIMockGetOptionsBatchProcess.Lock()
+	mock.calls.GetOptionsBatchProcess = append(mock.calls.GetOptionsBatchProcess, callInfo)
+	lockDatasetAPIMockGetOptionsBatchProcess.Unlock()
+	return mock.GetOptionsBatchProcessFunc(ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, optionIDs, processBatch, batchSize, maxWorkers)
 }
 
-// GetOptionsCalls gets all the calls that were made to GetOptions.
+// GetOptionsBatchProcessCalls gets all the calls that were made to GetOptionsBatchProcess.
 // Check the length with:
-//     len(mockedDatasetAPI.GetOptionsCalls())
-func (mock *DatasetAPIMock) GetOptionsCalls() []struct {
+//     len(mockedDatasetAPI.GetOptionsBatchProcessCalls())
+func (mock *DatasetAPIMock) GetOptionsBatchProcessCalls() []struct {
 	Ctx              context.Context
 	UserAuthToken    string
 	ServiceAuthToken string
@@ -152,7 +164,10 @@ func (mock *DatasetAPIMock) GetOptionsCalls() []struct {
 	Edition          string
 	Version          string
 	Dimension        string
-	Q                dataset.QueryParams
+	OptionIDs        *[]string
+	ProcessBatch     dataset.OptionsBatchProcessor
+	BatchSize        int
+	MaxWorkers       int
 } {
 	var calls []struct {
 		Ctx              context.Context
@@ -163,11 +178,14 @@ func (mock *DatasetAPIMock) GetOptionsCalls() []struct {
 		Edition          string
 		Version          string
 		Dimension        string
-		Q                dataset.QueryParams
+		OptionIDs        *[]string
+		ProcessBatch     dataset.OptionsBatchProcessor
+		BatchSize        int
+		MaxWorkers       int
 	}
-	lockDatasetAPIMockGetOptions.RLock()
-	calls = mock.calls.GetOptions
-	lockDatasetAPIMockGetOptions.RUnlock()
+	lockDatasetAPIMockGetOptionsBatchProcess.RLock()
+	calls = mock.calls.GetOptionsBatchProcess
+	lockDatasetAPIMockGetOptionsBatchProcess.RUnlock()
 	return calls
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	DownloadServiceSecretKey   string        `envconfig:"DOWNLOAD_SERVICE_SECRET_KEY"      json:"-"`
 	MaxRequestOptions          int           `envconfig:"MAX_REQUEST_OPTIONS"`
 	MaxDatasetOptions          int           `envconfig:"MAX_DATASET_OPTIONS"`
+	BatchMaxWorkers            int           `envconfig:"BATCH_MAX_WORKERS"`
 	KafkaVersion               string        `envconfig:"KAFKA_VERSION"`
 	MongoConfig                MongoConfig
 }
@@ -60,6 +61,7 @@ func Get() (*Config, error) {
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		MaxRequestOptions:          1000, // Maximum number of options acceptable in an incoming Patch request. Compromise between one option per call (inefficient) and an order of 100k options per call, for census data (memory and computationally expensive)
 		MaxDatasetOptions:          200,  // Maximum number of options requested to Dataset API in a single call.
+		BatchMaxWorkers:            25,   // maximum number of concurrent go-routines requesting items concurrently from APIs with pagination
 		MongoConfig: MongoConfig{
 			BindAddr:          "localhost:27017",
 			Database:          "filters",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-filter-api
 go 1.15
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.32.1
+	github.com/ONSdigital/dp-api-clients-go v1.32.2-0.20210105125646-318bb2d3bb05
 	github.com/ONSdigital/dp-graph/v2 v2.3.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-filter-api
 go 1.15
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.32.2-0.20210105125646-318bb2d3bb05
+	github.com/ONSdigital/dp-api-clients-go v1.32.3
 	github.com/ONSdigital/dp-graph/v2 v2.3.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.32.2-0.20210105125646-318bb2d3bb05 h1:SVzSWqD2vfpVxMpM/fLqYA4jWbNZEbAFP0+dP0qG094=
-github.com/ONSdigital/dp-api-clients-go v1.32.2-0.20210105125646-318bb2d3bb05/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.32.3 h1:9H1dMLoIV58NosDgBsICBX5qUpH9PCsG15R+HnthrR8=
+github.com/ONSdigital/dp-api-clients-go v1.32.3/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-graph/v2 v2.3.0 h1:xK9qImVbh86l04aAUeurjB7d8mwn27eacP+5gpvPLO8=
 github.com/ONSdigital/dp-graph/v2 v2.3.0/go.mod h1:K4LIhFcyxB8g7nUG5I5I8x6QVf89x82dCEFBbE0mmaQ=
@@ -175,6 +175,7 @@ golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.32.1 h1:LKmld3zgouccCGW2RizLZeUIEvIfAUO8VEuPMGLau88=
-github.com/ONSdigital/dp-api-clients-go v1.32.1/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.32.2-0.20210105125646-318bb2d3bb05 h1:SVzSWqD2vfpVxMpM/fLqYA4jWbNZEbAFP0+dP0qG094=
+github.com/ONSdigital/dp-api-clients-go v1.32.2-0.20210105125646-318bb2d3bb05/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-graph/v2 v2.3.0 h1:xK9qImVbh86l04aAUeurjB7d8mwn27eacP+5gpvPLO8=
 github.com/ONSdigital/dp-graph/v2 v2.3.0/go.mod h1:K4LIhFcyxB8g7nUG5I5I8x6QVf89x82dCEFBbE0mmaQ=


### PR DESCRIPTION
### What

(depends on https://github.com/ONSdigital/dp-api-clients-go/pull/84)
- Use `GetOptionsBatchProcess` instead of `GetOptions` to validate options by ID with dataset API.
- Adapted unit tests accordingly

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (optinal) I already tested it manually:
  - export a small batch size: `export MAX_DATASET_OPTIONS=2`
  - `make debug`
  - With postman, apply a patch with 5 IDs: {id1, id2, id3, id4, id5}
  - Check logs and validate that the dataset api is called 3 times: {id1, id2}, {id3, id4}, {id5}

### Who can review

Anyone