### PR TITLE
If a dimension does not provide options, don't try to check them

### DIFF
--- a/api/filters.go
+++ b/api/filters.go
@@ -474,6 +474,11 @@ func (api *FilterAPI) getDimensions(ctx context.Context, dataset *models.Dataset
 // getDimensionOptionsBatchProcess calls dataset API GetOptionsBatchProcess with the provided batch processor
 func (api *FilterAPI) getDimensionOptionsBatchProcess(ctx context.Context, dimension models.Dimension, dataset *models.Dataset, processBatch datasetAPI.OptionsBatchProcessor) error {
 
+	// if no options are defined, there is nothing to validate against dataset API
+	if dimension.Options == nil || len(dimension.Options) == 0 {
+		return nil
+	}
+
 	err := api.datasetAPI.GetOptionsBatchProcess(ctx,
 		getUserAuthToken(ctx),
 		api.serviceAuthToken,


### PR DESCRIPTION
### What

Bug fix: for dimensions with empty lists of options, we used did a call to validate with offset=0 and limit=0. This is wrong and unnecessary, so we handle the case by returning early if no options are provided (nothing to validate)

### How to review

Make sure code changes make sense

### Who can review

Anyone