### PR TITLE
Upgrade dp-api-clients-go version to make sure the list of IDs is correctly escaped.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-filter-api
 go 1.15
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.32.3
+	github.com/ONSdigital/dp-api-clients-go v1.32.6
 	github.com/ONSdigital/dp-graph/v2 v2.3.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.32.3 h1:9H1dMLoIV58NosDgBsICBX5qUpH9PCsG15R+HnthrR8=
-github.com/ONSdigital/dp-api-clients-go v1.32.3/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.32.6 h1:jLAhlSAFx8iV9P9K5TBEkzQMnl3gxAT5IzvyKSE3tQ0=
+github.com/ONSdigital/dp-api-clients-go v1.32.6/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-graph/v2 v2.3.0 h1:xK9qImVbh86l04aAUeurjB7d8mwn27eacP+5gpvPLO8=
 github.com/ONSdigital/dp-graph/v2 v2.3.0/go.mod h1:K4LIhFcyxB8g7nUG5I5I8x6QVf89x82dCEFBbE0mmaQ=


### PR DESCRIPTION
### What

Upgrade dp-api-clients-go version to make sure the list of IDs is correctly escaped.

### How to review

Make sure that the version of `dp-api-clients-go` is updated to 1.32.6

### Who can review

Anyone