### PR TITLE
upgrade dp-kafka to v2.4.3 for healtcheck WARNING fix

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,7 +62,7 @@ func Get() (*Config, error) {
 	cfg = &Config{
 		Host:                       "http://localhost:22100",
 		BindAddr:                   ":22100",
-		Brokers:                    []string{"localhost:9092"},
+		Brokers:                    []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 		KafkaVersion:               "1.0.2",
 		FilterOutputSubmittedTopic: "filter-job-submitted",
 		KafkaMaxBytes:              2000000,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.BindAddr, ShouldEqual, ":22100")
 				So(cfg.Host, ShouldEqual, "http://localhost:22100")
 				So(cfg.MaxRequestOptions, ShouldEqual, 1000)
-				So(cfg.Brokers, ShouldResemble, []string{"localhost:9092"})
+				So(cfg.Brokers, ShouldResemble, []string{"localhost:9092", "localhost:9093", "localhost:9094"})
 				So(cfg.KafkaVersion, ShouldEqual, "1.0.2")
 				So(cfg.KafkaSecProtocol, ShouldEqual, "")
 				So(cfg.FilterOutputSubmittedTopic, ShouldEqual, "filter-job-submitted")

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.43.0
 	github.com/ONSdigital/dp-healthcheck v1.2.1
-	github.com/ONSdigital/dp-kafka/v2 v2.4.1
+	github.com/ONSdigital/dp-kafka/v2 v2.4.3
 	github.com/ONSdigital/dp-mongodb/v3 v3.0.0-beta.5
 	github.com/ONSdigital/dp-net v1.2.0
 	github.com/ONSdigital/go-ns v0.0.0-20210410105122-6d6a140e952e

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf
 github.com/ONSdigital/dp-healthcheck v1.1.0/go.mod h1:vZwyjMJiCHjp/sJ2R1ZEqzZT0rJ0+uHVGwxqdP4J5vg=
 github.com/ONSdigital/dp-healthcheck v1.2.1 h1:HL0zHV5FI2Ym31gdMVNW9VLWiEJ0nrwXkVKX1MMPNr4=
 github.com/ONSdigital/dp-healthcheck v1.2.1/go.mod h1:XUhXoDIWPCdletDtpDOoXhmDFcc9b/kbedx96jN75aI=
-github.com/ONSdigital/dp-kafka/v2 v2.4.1 h1:e4nTpfsqb/gRRF3ZgstZ8mEjONvt+QPoWKbZoRg5dU8=
-github.com/ONSdigital/dp-kafka/v2 v2.4.1/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3 h1:Sb5nc4M3RsDMDmclsTqyjTMP6IBD7dRkv3kaIM26LLs=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-mongodb-in-memory v1.1.0 h1:EjUU1zpIU1LElhiTMAG7qxy7Rq9+VTUtt3/lyA+K7jI=


### PR DESCRIPTION
### What

- Upgrade `dp-kafka` dependency to v2.4.3 to use the healthcheck fix where kafka producers/consumers will have a `warning` health (instead of `critical`) if enough brokers are available
  - min 2 brokers for producers
  - min 1 broker for consumers
- kafkaAddr match brokers in dp-compose

### How to review

Make sure `dp-kafka` dependency is upgraded

### Who can review

anyone