### PR TITLE
updated swagger spec to match target contract

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -551,6 +551,10 @@ definitions:
           description: "A list of dimensions in the filter job"
           items:
              $ref: '#/definitions/DimensionOptions'
+        population_type:
+          description: "If specifying a custom filter, the population type that the data should be queried from"
+          example: "Teaching-Dataset"
+          type: string
   UpdateFilterRequest:
     description: "A model used to update filters. Dimensions are optional, while downloads and events are for internal use only."
     allOf:
@@ -644,6 +648,8 @@ definitions:
       version:
         type: integer
         description: "A version of a dataset"
+      is_based_on:
+        $ref: '#/definitions/IsBasedOn'
   Dimension:
     type: object
     description: "A dimension to filter on a dataset. Information on a dimension can be gathered using the `Dataset API`"
@@ -678,6 +684,16 @@ definitions:
         $ref: '#/definitions/DownloadFile'
       csv:
         $ref: '#/definitions/DownloadFile'
+  IsBasedOn:
+    type: object
+    description: If the dataset is related to Census, which population-type the dataset is taken from, and the type of dataset
+    properties:
+      id:
+        type: string
+        description: the population-type the dataset is based on
+      type:
+        type: string
+        description: the type of dataset
   Option:
     type: object
     description: "An option for a dimension to filter on a dataset. Information on a dimension option can be gathered using the `Dataset API`"


### PR DESCRIPTION
### What

Attempted to correct the filter-api swagger spec for POST to /filters

1. Added "population_type" field (type string) which is an optional field understood by upstream service dp-cantabular-filter-flex-api
2. Added missing "is_based_on" field do Dataset
3. Added the model for IsBasedOn - copied directly from dp-cantabular-filter-flex

### How to review

Things to consider:
1. population_type field is using the OpenAPI `type` keyword to set the data type, but dp-cantabular-filter-flex service uses the `format` keyword for the same thing - not sure if it matters that they're different (official spec doesn't seem to clarify, but normally base types use the `type` keyword)
2. Adding the is_based_on field to the model for Dataset will add this as an optional field for _every endpoint which uses this definition_. Is that ok?

### Who can review

@ChrysmOre and @franmoore05 