### PR TITLE
Add putFilterBlueprintDimensionHandler handler

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -93,6 +93,7 @@ func Setup(
 	api.Router.Handle("/filters", assert.DatasetType(http.HandlerFunc(api.postFilterBlueprintHandler))).Methods("POST")
 	api.Router.Handle("/filters/{filter_blueprint_id}", assert.FilterType(http.HandlerFunc(api.getFilterBlueprintHandler))).Methods("GET")
 	api.Router.Handle("/filters/{filter_blueprint_id}/dimensions", assert.FilterType(http.HandlerFunc(api.getFilterBlueprintDimensionsHandler))).Methods("GET")
+	api.Router.Handle("/filters/{filter_blueprint_id}/dimensions/{name}", assert.FilterType(http.HandlerFunc(api.putFilterBlueprintDimensionHandler))).Methods("PUT")
 
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}", api.putFilterBlueprintHandler).Methods("PUT")
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}", api.getFilterBlueprintDimensionHandler).Methods("GET")

--- a/api/filter_dimensions.go
+++ b/api/filter_dimensions.go
@@ -299,6 +299,24 @@ func (api *FilterAPI) addFilterBlueprintDimensionHandler(w http.ResponseWriter, 
 	log.Info(ctx, "created new dimension for filter blueprint", logData)
 }
 
+// Handler for a list of put operations against the filter dimensions
+func (api *FilterAPI) putFilterBlueprintDimensionHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	filterBlueprintID := vars["filter_blueprint_id"]
+	dimensionName := vars["name"]
+
+	logData := log.Data{
+		"filter_blueprint_id": filterBlueprintID,
+		"dimension":           dimensionName,
+	}
+	ctx := r.Context()
+	log.Info(ctx, "put filter blueprint dimension", logData)
+
+	err := errors.New("filter not of type flexible")
+	log.Error(ctx, "invalid filter type", err, logData)
+	http.Error(w, BadRequest, http.StatusBadRequest)
+}
+
 func (api *FilterAPI) addFilterBlueprintDimension(ctx context.Context, filterBlueprintID, dimensionName string, options []string, eTag string) (newETag string, err error) {
 
 	filterBlueprint, err := api.getFilterBlueprint(ctx, filterBlueprintID, eTag)

--- a/models/models.go
+++ b/models/models.go
@@ -101,9 +101,10 @@ type LinkObject struct {
 
 // Dimension represents an object containing a list of dimension values and the dimension name
 type Dimension struct {
-	URL     string   `bson:"dimension_url,omitempty" json:"dimension_url,omitempty"`
-	Name    string   `bson:"name"                    json:"name"`
-	Options []string `bson:"options,omitempty"                 json:"options"`
+	URL        string   `bson:"dimension_url,omitempty" json:"dimension_url,omitempty"`
+	Name       string   `bson:"name"                    json:"name"`
+	Options    []string `bson:"options,omitempty"       json:"options"`
+	IsAreaType *bool    `bson:"is_area_type,omitempty"  json:"is_area_type,omitempty"`
 }
 
 // EncodedOptions returns the list of options for this dimension after escaping the values for URL query paramters

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -271,6 +271,31 @@ paths:
           description: "Unprocessable entity - instance has been removed"
         500:
           $ref: '#/responses/InternalError'
+    put:
+      tags:
+      - "Public"
+      summary: "Update a dimension"
+      description: "Update the filter by updating a selected dimension"
+      parameters:
+      - $ref: '#/parameters/dimension'
+      - $ref: '#/parameters/if_match'
+      responses:
+        200:
+          description: "The dimension has been updated"
+          schema:
+            $ref: '#/definitions/Dimension'
+          headers:
+            ETag:
+              type: string
+              description: "Defines a unique filter resource version"
+        400:
+          description: "Invalid request body, filter does not exist, or If-Match header not provided"
+        404:
+          description: "Dimension was not found"
+        409:
+          description: '#/responses/FilterConflict'
+        500:
+          $ref: '#/responses/InternalError'
     patch:
       tags:
       - "Public"
@@ -663,6 +688,9 @@ definitions:
         items:
           type: string
           example: "/filters/00001/dimensions/age"
+      is_area_type:
+        type: boolean
+        description: Indicates if the dimension is an area type
   DimensionOptions:
     type: object
     description: "A dimension to filter on a dataset. Information on a dimension can be gathered using the `Dataset API`"


### PR DESCRIPTION
### What

Adds `putFilterBlueprintDimensionHandler` to handle `PUT` requests to `/filters/{filter_blueprint_id}/dimensions/{name}`.
If the given filter is flexible then the request is forwarded to the `dp-cantabular-filter-flex-api` if not an error is returned.

Context:
[https://trello.com/c/vUgHxQLq/5623-add-put-filters-id-dimensons-name-endpoint-to-dp-cantabular-filter-flex-api](https://trello.com/c/vUgHxQLq/5623-add-put-filters-id-dimensons-name-endpoint-to-dp-cantabular-filter-flex-api)

### How to review

Check the code and API spec makes sense.

### Who can review

Anyone.
