### PR TITLE
Check filter type on get filter outputs endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -105,7 +105,7 @@ func Setup(
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}/options/{option}", api.addFilterBlueprintDimensionOptionHandler).Methods("POST")
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}/options/{option}", api.removeFilterBlueprintDimensionOptionHandler).Methods("DELETE")
 
-	api.Router.HandleFunc("/filter-outputs/{filter_output_id}", api.getFilterOutputHandler).Methods("GET")
+	api.Router.Handle("/filter-outputs/{filter_output_id}", assert.FilterType(http.HandlerFunc(api.getFilterOutputHandler))).Methods("GET")
 
 	if cfg.EnablePrivateEndpoints {
 		api.Router.HandleFunc("/filter-outputs/{filter_output_id}", api.updateFilterOutputHandler).Methods("PUT")


### PR DESCRIPTION
### What

Proxies get filter outputs requests for flexible datasets onto `dp-cantabular-filter-flex-api`.
Context: [https://trello.com/c/4aCeV3JV/5638-add-proxy-request-to-cantabular-filter-flex-api-in-filter-api-for-get-filter-outputs](https://trello.com/c/4aCeV3JV/5638-add-proxy-request-to-cantabular-filter-flex-api-in-filter-api-for-get-filter-outputs)

### How to review

Check code and tests.

### Who can review

Anyone
