### PR TITLE
Revert "Check filter type on get filter outputs endpoint"

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -105,7 +105,7 @@ func Setup(
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}/options/{option}", api.addFilterBlueprintDimensionOptionHandler).Methods("POST")
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}/options/{option}", api.removeFilterBlueprintDimensionOptionHandler).Methods("DELETE")
 
-	api.Router.Handle("/filter-outputs/{filter_output_id}", assert.FilterType(http.HandlerFunc(api.getFilterOutputHandler))).Methods("GET")
+	api.Router.HandleFunc("/filter-outputs/{filter_output_id}", api.getFilterOutputHandler).Methods("GET")
 
 	if cfg.EnablePrivateEndpoints {
 		api.Router.HandleFunc("/filter-outputs/{filter_output_id}", api.updateFilterOutputHandler).Methods("PUT")

--- a/api/filter_outputs_test.go
+++ b/api/filter_outputs_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"bytes"
 	"context"
 	"testing"
 
@@ -133,46 +132,6 @@ func TestFailedToGetFilterOutput(t *testing.T) {
 
 		response := w.Body.String()
 		So(response, ShouldResemble, filters.ErrFilterOutputNotFound.Error()+"\n")
-	})
-}
-
-func TestFlexibleGetFilterOutput(t *testing.T) {
-	t.Parallel()
-
-	Convey("When the filter is flexible, the request is forwarded to dp-cantabular-filter-flex-api", t, func() {
-		conf := cfg()
-		conf.AssertDatasetType = true
-
-		w := httptest.NewRecorder()
-		filterFlexAPIMock := &apimock.FilterFlexAPIMock{
-			ForwardRequestFunc: func(r *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte("test body"))),
-				}, nil
-			},
-		}
-		datastoreMock := mock.NewDataStore().Mock
-		datastoreMock.GetFilterFunc = func(ctx context.Context, filterID, etag string) (*models.Filter, error) {
-			return &models.Filter{
-				Type: "flexible",
-			}, nil
-		}
-
-		filterApi := api.Setup(conf, mux.NewRouter(), datastoreMock, &mock.FilterJob{}, &mock.DatasetAPI{}, filterFlexAPIMock)
-
-		r, err := http.NewRequest("GET", "http://localhost:22100/filter-outputs/12345678", nil)
-		So(err, ShouldBeNil)
-		filterApi.Router.ServeHTTP(w, r)
-
-		Convey("A call to datastore is made to check the dataset type", func() {
-			So(datastoreMock.GetFilterCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("The request is forwarded to dp-cantabular-filter-flex-api", func() {
-			So(filterFlexAPIMock.ForwardRequestCalls(), ShouldHaveLength, 1)
-		})
-
 	})
 }
 


### PR DESCRIPTION
This reverts commit d148e53f018bff864ed2aaa65498b7f9cbbc5daa.

### What

Reverts the changes from https://github.com/ONSdigital/dp-filter-api/pull/237.

A fix is being worked on to enable this functionality but for the time being we will revert.

### How to review

Check the correct changes are reverted.

### Who can review

Anyone.
