### PR TITLE
Fix GET /filter-outputs/{id} endpoint 

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -109,7 +109,7 @@ func Setup(
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}/options/{option}", api.getFilterBlueprintDimensionOptionHandler).Methods("GET")
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}/options/{option}", api.addFilterBlueprintDimensionOptionHandler).Methods("POST")
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}/options/{option}", api.removeFilterBlueprintDimensionOptionHandler).Methods("DELETE")
-	api.Router.Handle("/filter-outputs/{filter_output_id}", assert.FilterType(http.HandlerFunc(api.getFilterOutputHandler))).Methods("GET")
+	api.Router.Handle("/filter-outputs/{filter_output_id}", assert.FilterOutputFilterType(http.HandlerFunc(api.getFilterOutputHandler))).Methods("GET")
 
 	if cfg.EnablePrivateEndpoints {
 		api.Router.Handle("/filter-outputs/{filter_output_id}", assert.FilterOutputFilterType(http.HandlerFunc(api.updateFilterOutputHandler))).Methods("PUT")

--- a/api/filter_outputs_test.go
+++ b/api/filter_outputs_test.go
@@ -2,13 +2,15 @@ package api_test
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
-
-	"encoding/json"
-	"net/http/httptest"
-	"strings"
 
 	"github.com/ONSdigital/dp-filter-api/api"
 	apimock "github.com/ONSdigital/dp-filter-api/api/mock"
@@ -16,10 +18,6 @@ import (
 	"github.com/ONSdigital/dp-filter-api/models"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
-
-	"errors"
-	"io"
-	"net/http"
 
 	"github.com/ONSdigital/dp-filter-api/mock"
 	dprequest "github.com/ONSdigital/dp-net/request"


### PR DESCRIPTION
### What

Filtering on CMD datasets is currently broken in develop. Once selections
are made by the user and the button is pressed to generate a download
an error is returned.

An error screen is displayed. When looking for the UUID in the URL bar
at the top of the screen in Kibana the below error is returned.

```
"{ "status_code": 500, "response": "failed to get dataset: filter blueprint not found", "error": "failed to get dataset: filter blueprint not found" }"
```

This is due to the `assert.FilterType(...)` being used instead of the
`assert.FilterOutputHandler(...)`

Resolves: [5669](https://trello.com/c/xp5yM8Gp/5669-cmd-filtering-is-broken-on-website-develop)

### How to review

Review and test locally.

### Who can review

Any developer from Team B
