### PR TITLE
Search filterOutputs using 'filter_id' instead of 'id'

### DIFF
--- a/mongo/filterstore.go
+++ b/mongo/filterstore.go
@@ -379,7 +379,7 @@ func (s *FilterStore) CreateFilterOutput(ctx context.Context, filter *models.Fil
 func (s *FilterStore) GetFilterOutput(ctx context.Context, filterID string) (*models.Filter, error) {
 	// NOTE: previously was filter_id.
 	// This should be _id/id. Confirm during PR.
-	query := bson.M{"id": filterID}
+	query := bson.M{"filter_id": filterID}
 	var result *models.Filter
 
 	if err := s.Connection.Collection(s.ActualCollectionName(config.OutputsCollection)).FindOne(ctx, query, &result); err != nil {

--- a/mongo/filterstore_test.go
+++ b/mongo/filterstore_test.go
@@ -1,8 +1,9 @@
 package mongo
 
 import (
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"testing"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/ONSdigital/dp-filter-api/models"
 	. "github.com/smartystreets/goconvey/convey"
@@ -74,10 +75,8 @@ func TestCreateUpdateFilterOutput(t *testing.T) {
 
 func TestSelector(t *testing.T) {
 
-	Convey("Given some testing values to provide as selector paramters", t, func() {
-		var testFilterID string = "filterID"
-		var testDimensionName string = "dimensionName"
-		var testETag string = "testETag"
+	Convey("Given some testing values to provide as selector parameters", t, func() {
+		var testETag = "testETag"
 		var testMongoTimestamp = primitive.Timestamp{1234567890, 0}
 
 		Convey("Then, providing an empty string dimension, zero timestamp and any eTag generates a selector that only queries by filter_id", func() {


### PR DESCRIPTION
### What

We are not able to search the `CMD` dataset at the moment, as we were searching for an `id` key instead of the `filter_id` key.

Resolves [5669](https://trello.com/c/xp5yM8Gp/5669-cmd-filtering-is-broken-on-website-develop)

### How to review

Review code.

### Who can review

Any developer
