### PR TITLE
Search filterOutput collection via "filter_id" or "id"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.100.0
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-kafka/v2 v2.4.4
+	github.com/ONSdigital/dp-mongodb-in-memory v1.3.0
 	github.com/ONSdigital/dp-mongodb/v3 v3.0.0
 	github.com/ONSdigital/dp-net v1.2.0
 	github.com/ONSdigital/dp-net/v2 v2.4.0-beta
@@ -18,7 +19,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/smartystreets/goconvey v1.7.2
-	go.mongodb.org/mongo-driver v1.8.0
+	go.mongodb.org/mongo-driver v1.9.1
 )
 
 require (
@@ -46,6 +47,7 @@ require (
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/smartystreets/assertions v1.2.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
 	github.com/square/mongo-lock v0.0.0-20201208161834-4db518ed7fb2 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,9 @@ github.com/ONSdigital/dp-kafka/v2 v2.4.4 h1:YHURygN7YVQTJ+2E7DrqbJMWSTUJJ6+9TjeN
 github.com/ONSdigital/dp-kafka/v2 v2.4.4/go.mod h1:8fTKJ8F06nmTA3ixRnbUwfi9n+sQDfltw5d9uLJQtug=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
-github.com/ONSdigital/dp-mongodb-in-memory v1.1.0 h1:EjUU1zpIU1LElhiTMAG7qxy7Rq9+VTUtt3/lyA+K7jI=
 github.com/ONSdigital/dp-mongodb-in-memory v1.1.0/go.mod h1:AQaNcbSS18WtldA4iWUlHQDn9FCLB2K6ff68QnvZBqM=
+github.com/ONSdigital/dp-mongodb-in-memory v1.3.0 h1:j/KGcYsT6OCbOs6Exv8W8TwQql5Qao6S/h6xsXie7nA=
+github.com/ONSdigital/dp-mongodb-in-memory v1.3.0/go.mod h1:AQaNcbSS18WtldA4iWUlHQDn9FCLB2K6ff68QnvZBqM=
 github.com/ONSdigital/dp-mongodb/v3 v3.0.0 h1:VjhOpjcGH6dZrvLBtzcTcGyFg7ElBMG9UDB8cOrxhk8=
 github.com/ONSdigital/dp-mongodb/v3 v3.0.0/go.mod h1:8rceYZlPQVy5UpQp6QrJjS26+3p+Atidi6GZMPUdc/Y=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
@@ -278,8 +279,9 @@ github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a/go.mod h1:ul22v+Nro/
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.mongodb.org/mongo-driver v1.4.2/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
-go.mongodb.org/mongo-driver v1.8.0 h1:R/P/JJzu8LJvJ1lDfph9GLNIKQxEtIHFfnUUUve35zY=
 go.mongodb.org/mongo-driver v1.8.0/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
+go.mongodb.org/mongo-driver v1.9.1 h1:m078y9v7sBItkt1aaoe2YlvWEXcD263e1a4E1fBrJ1c=
+go.mongodb.org/mongo-driver v1.9.1/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190422162423-af44ce270edf/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=

--- a/models/models.go
+++ b/models/models.go
@@ -47,7 +47,7 @@ type Filter struct {
 	LastUpdated     time.Time           `bson:"last_updated"               json:"-"`
 	ETag            string              `bson:"e_tag"                      json:"-"`
 
-	ID         string      `bson:"-"                    json:"id,omitempty"`
+	ID         string      `bson:"id"                    json:"id,omitempty"`
 	Dataset    *Dataset    `bson:"dataset"              json:"dataset"`
 	InstanceID string      `bson:"instance_id"          json:"instance_id"`
 	Dimensions []Dimension `bson:"dimensions,omitempty" json:"dimensions,omitempty"`

--- a/mongo/filterstore.go
+++ b/mongo/filterstore.go
@@ -377,9 +377,9 @@ func (s *FilterStore) CreateFilterOutput(ctx context.Context, filter *models.Fil
 
 // GetFilterOutput returns a filter output resource
 func (s *FilterStore) GetFilterOutput(ctx context.Context, filterID string) (*models.Filter, error) {
-	// NOTE: previously was filter_id.
-	// This should be _id/id. Confirm during PR.
-	query := bson.M{"filter_id": filterID}
+	// we have to match either the filter_id (in CMD) or the id (in Cantabular)
+	// This way we support both CMD and Cantabular
+	query := bson.M{"$or": []bson.M{{"filter_id": filterID}, {"id": filterID}}}
 	var result *models.Filter
 
 	if err := s.Connection.Collection(s.ActualCollectionName(config.OutputsCollection)).FindOne(ctx, query, &result); err != nil {


### PR DESCRIPTION
### What

In CMD we search by `filter_id`, but on Cantabular we search by a new
field called `id`.

This addresses the approach of simply changing the MongoDB query.

Resolves: [5690](https://trello.com/c/ZDZgbMyz/5690-copy-getfilteroutput-function-from-dp-filter-api-and-amend-for-cantabular-filter-output-search)

### How to review

Review the changes and run them locally

### Who can review

Any ONS developer
