### PR TITLE
Search filterOutput collection via "filter_id" or "id"

### DIFF
--- a/api/datastore.go
+++ b/api/datastore.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/ONSdigital/dp-filter-api/models"
@@ -22,7 +23,8 @@ type DataStore interface {
 	RemoveFilterDimensionOption(ctx context.Context, filterID string, name string, option string, timestamp primitive.Timestamp, eTagSelector string, currentFilter *models.Filter) (newETag string, err error)
 	RemoveFilterDimensionOptions(ctx context.Context, filterID string, name string, options []string, timestamp primitive.Timestamp, eTagSelector string, currentFilter *models.Filter) (newETag string, err error)
 	CreateFilterOutput(ctx context.Context, filter *models.Filter) error
-	GetFilterOutput(ctx context.Context, filterOutputID string) (*models.Filter, error)
+	GetFilterOutput(ctx context.Context, filterID string) (*models.Filter, error)
+	GetCantabularFilterOutput(ctx context.Context, filterOutputID string) (*models.Filter, error)
 	UpdateFilterOutput(ctx context.Context, filter *models.Filter, timestamp primitive.Timestamp) error
 	AddEventToFilterOutput(ctx context.Context, filterOutputID string, event *models.Event) error
 }

--- a/api/mock/datastore.go
+++ b/api/mock/datastore.go
@@ -39,13 +39,16 @@ var _ api.DataStore = &DataStoreMock{}
 // 			CreateFilterOutputFunc: func(ctx context.Context, filter *models.Filter) error {
 // 				panic("mock out the CreateFilterOutput method")
 // 			},
+// 			GetCantabularFilterOutputFunc: func(ctx context.Context, filterOutputID string) (*models.Filter, error) {
+// 				panic("mock out the GetCantabularFilterOutput method")
+// 			},
 // 			GetFilterFunc: func(ctx context.Context, filterID string, eTagSelector string) (*models.Filter, error) {
 // 				panic("mock out the GetFilter method")
 // 			},
 // 			GetFilterDimensionFunc: func(ctx context.Context, filterID string, name string, eTagSelector string) (*models.Dimension, error) {
 // 				panic("mock out the GetFilterDimension method")
 // 			},
-// 			GetFilterOutputFunc: func(ctx context.Context, filterOutputID string) (*models.Filter, error) {
+// 			GetFilterOutputFunc: func(ctx context.Context, filterID string) (*models.Filter, error) {
 // 				panic("mock out the GetFilterOutput method")
 // 			},
 // 			RemoveFilterDimensionFunc: func(ctx context.Context, filterID string, name string, timestamp primitive.Timestamp, eTagSelector string, currentFilter *models.Filter) (string, error) {
@@ -88,6 +91,9 @@ type DataStoreMock struct {
 	// CreateFilterOutputFunc mocks the CreateFilterOutput method.
 	CreateFilterOutputFunc func(ctx context.Context, filter *models.Filter) error
 
+	// GetCantabularFilterOutputFunc mocks the GetCantabularFilterOutput method.
+	GetCantabularFilterOutputFunc func(ctx context.Context, filterOutputID string) (*models.Filter, error)
+
 	// GetFilterFunc mocks the GetFilter method.
 	GetFilterFunc func(ctx context.Context, filterID string, eTagSelector string) (*models.Filter, error)
 
@@ -95,7 +101,7 @@ type DataStoreMock struct {
 	GetFilterDimensionFunc func(ctx context.Context, filterID string, name string, eTagSelector string) (*models.Dimension, error)
 
 	// GetFilterOutputFunc mocks the GetFilterOutput method.
-	GetFilterOutputFunc func(ctx context.Context, filterOutputID string) (*models.Filter, error)
+	GetFilterOutputFunc func(ctx context.Context, filterID string) (*models.Filter, error)
 
 	// RemoveFilterDimensionFunc mocks the RemoveFilterDimension method.
 	RemoveFilterDimensionFunc func(ctx context.Context, filterID string, name string, timestamp primitive.Timestamp, eTagSelector string, currentFilter *models.Filter) (string, error)
@@ -190,6 +196,13 @@ type DataStoreMock struct {
 			// Filter is the filter argument value.
 			Filter *models.Filter
 		}
+		// GetCantabularFilterOutput holds details about calls to the GetCantabularFilterOutput method.
+		GetCantabularFilterOutput []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// FilterOutputID is the filterOutputID argument value.
+			FilterOutputID string
+		}
 		// GetFilter holds details about calls to the GetFilter method.
 		GetFilter []struct {
 			// Ctx is the ctx argument value.
@@ -214,8 +227,8 @@ type DataStoreMock struct {
 		GetFilterOutput []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// FilterOutputID is the filterOutputID argument value.
-			FilterOutputID string
+			// FilterID is the filterID argument value.
+			FilterID string
 		}
 		// RemoveFilterDimension holds details about calls to the RemoveFilterDimension method.
 		RemoveFilterDimension []struct {
@@ -295,6 +308,7 @@ type DataStoreMock struct {
 	lockAddFilterDimensionOption     sync.RWMutex
 	lockAddFilterDimensionOptions    sync.RWMutex
 	lockCreateFilterOutput           sync.RWMutex
+	lockGetCantabularFilterOutput    sync.RWMutex
 	lockGetFilter                    sync.RWMutex
 	lockGetFilterDimension           sync.RWMutex
 	lockGetFilterOutput              sync.RWMutex
@@ -583,6 +597,41 @@ func (mock *DataStoreMock) CreateFilterOutputCalls() []struct {
 	return calls
 }
 
+// GetCantabularFilterOutput calls GetCantabularFilterOutputFunc.
+func (mock *DataStoreMock) GetCantabularFilterOutput(ctx context.Context, filterOutputID string) (*models.Filter, error) {
+	if mock.GetCantabularFilterOutputFunc == nil {
+		panic("DataStoreMock.GetCantabularFilterOutputFunc: method is nil but DataStore.GetCantabularFilterOutput was just called")
+	}
+	callInfo := struct {
+		Ctx            context.Context
+		FilterOutputID string
+	}{
+		Ctx:            ctx,
+		FilterOutputID: filterOutputID,
+	}
+	mock.lockGetCantabularFilterOutput.Lock()
+	mock.calls.GetCantabularFilterOutput = append(mock.calls.GetCantabularFilterOutput, callInfo)
+	mock.lockGetCantabularFilterOutput.Unlock()
+	return mock.GetCantabularFilterOutputFunc(ctx, filterOutputID)
+}
+
+// GetCantabularFilterOutputCalls gets all the calls that were made to GetCantabularFilterOutput.
+// Check the length with:
+//     len(mockedDataStore.GetCantabularFilterOutputCalls())
+func (mock *DataStoreMock) GetCantabularFilterOutputCalls() []struct {
+	Ctx            context.Context
+	FilterOutputID string
+} {
+	var calls []struct {
+		Ctx            context.Context
+		FilterOutputID string
+	}
+	mock.lockGetCantabularFilterOutput.RLock()
+	calls = mock.calls.GetCantabularFilterOutput
+	mock.lockGetCantabularFilterOutput.RUnlock()
+	return calls
+}
+
 // GetFilter calls GetFilterFunc.
 func (mock *DataStoreMock) GetFilter(ctx context.Context, filterID string, eTagSelector string) (*models.Filter, error) {
 	if mock.GetFilterFunc == nil {
@@ -666,33 +715,33 @@ func (mock *DataStoreMock) GetFilterDimensionCalls() []struct {
 }
 
 // GetFilterOutput calls GetFilterOutputFunc.
-func (mock *DataStoreMock) GetFilterOutput(ctx context.Context, filterOutputID string) (*models.Filter, error) {
+func (mock *DataStoreMock) GetFilterOutput(ctx context.Context, filterID string) (*models.Filter, error) {
 	if mock.GetFilterOutputFunc == nil {
 		panic("DataStoreMock.GetFilterOutputFunc: method is nil but DataStore.GetFilterOutput was just called")
 	}
 	callInfo := struct {
-		Ctx            context.Context
-		FilterOutputID string
+		Ctx      context.Context
+		FilterID string
 	}{
-		Ctx:            ctx,
-		FilterOutputID: filterOutputID,
+		Ctx:      ctx,
+		FilterID: filterID,
 	}
 	mock.lockGetFilterOutput.Lock()
 	mock.calls.GetFilterOutput = append(mock.calls.GetFilterOutput, callInfo)
 	mock.lockGetFilterOutput.Unlock()
-	return mock.GetFilterOutputFunc(ctx, filterOutputID)
+	return mock.GetFilterOutputFunc(ctx, filterID)
 }
 
 // GetFilterOutputCalls gets all the calls that were made to GetFilterOutput.
 // Check the length with:
 //     len(mockedDataStore.GetFilterOutputCalls())
 func (mock *DataStoreMock) GetFilterOutputCalls() []struct {
-	Ctx            context.Context
-	FilterOutputID string
+	Ctx      context.Context
+	FilterID string
 } {
 	var calls []struct {
-		Ctx            context.Context
-		FilterOutputID string
+		Ctx      context.Context
+		FilterID string
 	}
 	mock.lockGetFilterOutput.RLock()
 	calls = mock.calls.GetFilterOutput

--- a/middleware/assert.go
+++ b/middleware/assert.go
@@ -54,11 +54,16 @@ func (a *Assert) FilterOutputFilterType(next http.Handler) http.Handler {
 		ctx := r.Context()
 		filterOutput, err := a.store.GetFilterOutput(ctx, filterOutputID)
 		if err != nil {
-			a.respond.Error(ctx, w, statusCode(err), er{
-				err: errors.Wrap(err, "failed to get filter output"),
-				msg: fmt.Sprintf("failed to get filter output"),
-			})
-			return
+			if statusCode(err) == http.StatusNotFound {
+				filterOutput, err = a.store.GetCantabularFilterOutput(ctx, filterOutputID)
+				if err != nil {
+					a.respond.Error(ctx, w, statusCode(err), er{
+						err: errors.Wrap(err, "failed to get filter output"),
+						msg: fmt.Sprintf("failed to get filter output"),
+					})
+					return
+				}
+			}
 		}
 
 		if filterOutput.Type == flexible {

--- a/middleware/interface.go
+++ b/middleware/interface.go
@@ -22,6 +22,7 @@ type filterFlexAPIClient interface {
 type datastore interface {
 	GetFilter(ctx context.Context, filterID, eTagSelector string) (*models.Filter, error)
 	GetFilterOutput(ctx context.Context, filterID string) (*models.Filter, error)
+	GetCantabularFilterOutput(ctx context.Context, filterOutputID string) (*models.Filter, error)
 }
 
 type dataLogger interface {

--- a/mock/datastore.go
+++ b/mock/datastore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	apimock "github.com/ONSdigital/dp-filter-api/api/mock"
@@ -78,6 +79,7 @@ func NewDataStore() *DataStore {
 		GetFilterFunc:                    ds.GetFilter,
 		GetFilterDimensionFunc:           ds.GetFilterDimension,
 		GetFilterOutputFunc:              ds.GetFilterOutput,
+		GetCantabularFilterOutputFunc:    ds.GetCantabularFilterOutput,
 		RemoveFilterDimensionFunc:        ds.RemoveFilterDimension,
 		RemoveFilterDimensionOptionFunc:  ds.RemoveFilterDimensionOption,
 		RemoveFilterDimensionOptionsFunc: ds.RemoveFilterDimensionOptions,
@@ -295,6 +297,11 @@ func (ds *DataStore) GetFilterDimension(ctx context.Context, filterID string, na
 	}
 
 	return &models.Dimension{Name: "1_age"}, nil
+}
+
+// GetCantabularFilterOutput represents the mocked version of getting a Cantabular filter output from the datastore
+func (ds *DataStore) GetCantabularFilterOutput(ctx context.Context, filterID string) (*models.Filter, error) {
+	return ds.GetFilterOutput(ctx, filterID)
 }
 
 // GetFilterOutput represents the mocked version of getting a filter output from the datastore

--- a/mongo/filterstore.go
+++ b/mongo/filterstore.go
@@ -377,9 +377,23 @@ func (s *FilterStore) CreateFilterOutput(ctx context.Context, filter *models.Fil
 
 // GetFilterOutput returns a filter output resource
 func (s *FilterStore) GetFilterOutput(ctx context.Context, filterID string) (*models.Filter, error) {
-	// NOTE: previously was filter_id.
-	// This should be _id/id. Confirm during PR.
 	query := bson.M{"filter_id": filterID}
+	var result *models.Filter
+
+	if err := s.Connection.Collection(s.ActualCollectionName(config.OutputsCollection)).FindOne(ctx, query, &result); err != nil {
+		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
+			return nil, filters.ErrFilterOutputNotFound
+		}
+
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetFilterOutput returns a filter output resource
+func (s *FilterStore) GetCantabularFilterOutput(ctx context.Context, filterOutputID string) (*models.Filter, error) {
+	query := bson.M{"id": filterOutputID}
 	var result *models.Filter
 
 	if err := s.Connection.Collection(s.ActualCollectionName(config.OutputsCollection)).FindOne(ctx, query, &result); err != nil {

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -42,7 +42,8 @@ type MongoDB interface {
 	RemoveFilterDimensionOption(ctx context.Context, filterID string, name string, option string, timestamp primitive.Timestamp, eTagSelector string, currentFilter *models.Filter) (newETag string, err error)
 	RemoveFilterDimensionOptions(ctx context.Context, filterID string, name string, options []string, timestamp primitive.Timestamp, eTagSelector string, currentFilter *models.Filter) (newETag string, err error)
 	CreateFilterOutput(ctx context.Context, filter *models.Filter) error
-	GetFilterOutput(ctx context.Context, filterOutputID string) (*models.Filter, error)
+	GetFilterOutput(ctx context.Context, filterID string) (*models.Filter, error)
+	GetCantabularFilterOutput(ctx context.Context, filterOutputID string) (*models.Filter, error)
 	UpdateFilterOutput(ctx context.Context, filter *models.Filter, timestamp primitive.Timestamp) error
 	AddEventToFilterOutput(ctx context.Context, filterOutputID string, event *models.Event) error
 	Checker(ctx context.Context, state *healthcheck.CheckState) error

--- a/service/mock/mongo.go
+++ b/service/mock/mongo.go
@@ -46,13 +46,16 @@ var _ service.MongoDB = &MongoDBMock{}
 // 			CreateFilterOutputFunc: func(ctx context.Context, filter *models.Filter) error {
 // 				panic("mock out the CreateFilterOutput method")
 // 			},
+// 			GetCantabularFilterOutputFunc: func(ctx context.Context, filterOutputID string) (*models.Filter, error) {
+// 				panic("mock out the GetCantabularFilterOutput method")
+// 			},
 // 			GetFilterFunc: func(ctx context.Context, filterID string, eTagSelector string) (*models.Filter, error) {
 // 				panic("mock out the GetFilter method")
 // 			},
 // 			GetFilterDimensionFunc: func(ctx context.Context, filterID string, name string, eTagSelector string) (*models.Dimension, error) {
 // 				panic("mock out the GetFilterDimension method")
 // 			},
-// 			GetFilterOutputFunc: func(ctx context.Context, filterOutputID string) (*models.Filter, error) {
+// 			GetFilterOutputFunc: func(ctx context.Context, filterID string) (*models.Filter, error) {
 // 				panic("mock out the GetFilterOutput method")
 // 			},
 // 			RemoveFilterDimensionFunc: func(ctx context.Context, filterID string, name string, timestamp primitive.Timestamp, eTagSelector string, currentFilter *models.Filter) (string, error) {
@@ -101,6 +104,9 @@ type MongoDBMock struct {
 	// CreateFilterOutputFunc mocks the CreateFilterOutput method.
 	CreateFilterOutputFunc func(ctx context.Context, filter *models.Filter) error
 
+	// GetCantabularFilterOutputFunc mocks the GetCantabularFilterOutput method.
+	GetCantabularFilterOutputFunc func(ctx context.Context, filterOutputID string) (*models.Filter, error)
+
 	// GetFilterFunc mocks the GetFilter method.
 	GetFilterFunc func(ctx context.Context, filterID string, eTagSelector string) (*models.Filter, error)
 
@@ -108,7 +114,7 @@ type MongoDBMock struct {
 	GetFilterDimensionFunc func(ctx context.Context, filterID string, name string, eTagSelector string) (*models.Dimension, error)
 
 	// GetFilterOutputFunc mocks the GetFilterOutput method.
-	GetFilterOutputFunc func(ctx context.Context, filterOutputID string) (*models.Filter, error)
+	GetFilterOutputFunc func(ctx context.Context, filterID string) (*models.Filter, error)
 
 	// RemoveFilterDimensionFunc mocks the RemoveFilterDimension method.
 	RemoveFilterDimensionFunc func(ctx context.Context, filterID string, name string, timestamp primitive.Timestamp, eTagSelector string, currentFilter *models.Filter) (string, error)
@@ -215,6 +221,13 @@ type MongoDBMock struct {
 			// Filter is the filter argument value.
 			Filter *models.Filter
 		}
+		// GetCantabularFilterOutput holds details about calls to the GetCantabularFilterOutput method.
+		GetCantabularFilterOutput []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// FilterOutputID is the filterOutputID argument value.
+			FilterOutputID string
+		}
 		// GetFilter holds details about calls to the GetFilter method.
 		GetFilter []struct {
 			// Ctx is the ctx argument value.
@@ -239,8 +252,8 @@ type MongoDBMock struct {
 		GetFilterOutput []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// FilterOutputID is the filterOutputID argument value.
-			FilterOutputID string
+			// FilterID is the filterID argument value.
+			FilterID string
 		}
 		// RemoveFilterDimension holds details about calls to the RemoveFilterDimension method.
 		RemoveFilterDimension []struct {
@@ -322,6 +335,7 @@ type MongoDBMock struct {
 	lockChecker                      sync.RWMutex
 	lockClose                        sync.RWMutex
 	lockCreateFilterOutput           sync.RWMutex
+	lockGetCantabularFilterOutput    sync.RWMutex
 	lockGetFilter                    sync.RWMutex
 	lockGetFilterDimension           sync.RWMutex
 	lockGetFilterOutput              sync.RWMutex
@@ -676,6 +690,41 @@ func (mock *MongoDBMock) CreateFilterOutputCalls() []struct {
 	return calls
 }
 
+// GetCantabularFilterOutput calls GetCantabularFilterOutputFunc.
+func (mock *MongoDBMock) GetCantabularFilterOutput(ctx context.Context, filterOutputID string) (*models.Filter, error) {
+	if mock.GetCantabularFilterOutputFunc == nil {
+		panic("MongoDBMock.GetCantabularFilterOutputFunc: method is nil but MongoDB.GetCantabularFilterOutput was just called")
+	}
+	callInfo := struct {
+		Ctx            context.Context
+		FilterOutputID string
+	}{
+		Ctx:            ctx,
+		FilterOutputID: filterOutputID,
+	}
+	mock.lockGetCantabularFilterOutput.Lock()
+	mock.calls.GetCantabularFilterOutput = append(mock.calls.GetCantabularFilterOutput, callInfo)
+	mock.lockGetCantabularFilterOutput.Unlock()
+	return mock.GetCantabularFilterOutputFunc(ctx, filterOutputID)
+}
+
+// GetCantabularFilterOutputCalls gets all the calls that were made to GetCantabularFilterOutput.
+// Check the length with:
+//     len(mockedMongoDB.GetCantabularFilterOutputCalls())
+func (mock *MongoDBMock) GetCantabularFilterOutputCalls() []struct {
+	Ctx            context.Context
+	FilterOutputID string
+} {
+	var calls []struct {
+		Ctx            context.Context
+		FilterOutputID string
+	}
+	mock.lockGetCantabularFilterOutput.RLock()
+	calls = mock.calls.GetCantabularFilterOutput
+	mock.lockGetCantabularFilterOutput.RUnlock()
+	return calls
+}
+
 // GetFilter calls GetFilterFunc.
 func (mock *MongoDBMock) GetFilter(ctx context.Context, filterID string, eTagSelector string) (*models.Filter, error) {
 	if mock.GetFilterFunc == nil {
@@ -759,33 +808,33 @@ func (mock *MongoDBMock) GetFilterDimensionCalls() []struct {
 }
 
 // GetFilterOutput calls GetFilterOutputFunc.
-func (mock *MongoDBMock) GetFilterOutput(ctx context.Context, filterOutputID string) (*models.Filter, error) {
+func (mock *MongoDBMock) GetFilterOutput(ctx context.Context, filterID string) (*models.Filter, error) {
 	if mock.GetFilterOutputFunc == nil {
 		panic("MongoDBMock.GetFilterOutputFunc: method is nil but MongoDB.GetFilterOutput was just called")
 	}
 	callInfo := struct {
-		Ctx            context.Context
-		FilterOutputID string
+		Ctx      context.Context
+		FilterID string
 	}{
-		Ctx:            ctx,
-		FilterOutputID: filterOutputID,
+		Ctx:      ctx,
+		FilterID: filterID,
 	}
 	mock.lockGetFilterOutput.Lock()
 	mock.calls.GetFilterOutput = append(mock.calls.GetFilterOutput, callInfo)
 	mock.lockGetFilterOutput.Unlock()
-	return mock.GetFilterOutputFunc(ctx, filterOutputID)
+	return mock.GetFilterOutputFunc(ctx, filterID)
 }
 
 // GetFilterOutputCalls gets all the calls that were made to GetFilterOutput.
 // Check the length with:
 //     len(mockedMongoDB.GetFilterOutputCalls())
 func (mock *MongoDBMock) GetFilterOutputCalls() []struct {
-	Ctx            context.Context
-	FilterOutputID string
+	Ctx      context.Context
+	FilterID string
 } {
 	var calls []struct {
-		Ctx            context.Context
-		FilterOutputID string
+		Ctx      context.Context
+		FilterID string
 	}
 	mock.lockGetFilterOutput.RLock()
 	calls = mock.calls.GetFilterOutput


### PR DESCRIPTION
### What

In CMD we search by `filter_id`, but on Cantabular we search by a new
field called `id`.

Resolves: [5690](https://trello.com/c/ZDZgbMyz/5690-copy-getfilteroutput-function-from-dp-filter-api-and-amend-for-cantabular-filter-output-search)

### How to review

Review code.

### Who can review

Any develop
