### PR TITLE
wrap /filters/{id}/dimensions/{dimension}/options/{option} with asser…

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -92,27 +92,26 @@ func Setup(
 	// routes
 	api.Router.Handle("/filters", assert.DatasetType(http.HandlerFunc(api.postFilterBlueprintHandler))).Methods("POST")
 	api.Router.Handle("/filters/{filter_blueprint_id}", assert.FilterType(http.HandlerFunc(api.getFilterBlueprintHandler))).Methods("GET")
-	api.Router.Handle("/filters/{filter_blueprint_id}/submit", assert.FilterType(http.HandlerFunc(api.postFilterBlueprintSubmitHandler))).Methods("POST")
-	api.Router.Handle("/filters/{filter_blueprint_id}/dimensions", assert.FilterType(http.HandlerFunc(api.getFilterBlueprintDimensionsHandler))).Methods("GET")
-
 	api.Router.Handle("/filters/{filter_blueprint_id}", assert.FilterType(http.HandlerFunc(api.putFilterBlueprintHandler))).Methods("PUT")
+	api.Router.Handle("/filters/{filter_blueprint_id}/submit", assert.FilterType(http.HandlerFunc(api.postFilterBlueprintSubmitHandler))).Methods("POST")
 
+	api.Router.Handle("/filters/{filter_blueprint_id}/dimensions", assert.FilterType(http.HandlerFunc(api.getFilterBlueprintDimensionsHandler))).Methods("GET")
 	api.Router.Handle("/filters/{filter_blueprint_id}/dimensions/{name}", assert.FilterType(http.HandlerFunc(api.putFilterBlueprintDimensionHandler))).Methods("PUT")
 	api.Router.Handle("/filters/{filter_blueprint_id}/dimensions/{name}", assert.FilterType(http.HandlerFunc(api.getFilterBlueprintDimensionHandler))).Methods("GET")
 
-	api.Router.HandleFunc("/filters/{filter_blueprint_id}", api.putFilterBlueprintHandler).Methods("PUT")
+	api.Router.Handle("/filters/{filter_blueprint_id}/dimensions/{name}/options/{option}", assert.FilterType(http.HandlerFunc(api.addFilterBlueprintDimensionOptionHandler))).Methods("POST")
+	api.Router.Handle("/filters/{filter_blueprint_id}/dimensions/{name}/options", assert.FilterType(http.HandlerFunc(api.getFilterBlueprintDimensionOptionsHandler))).Methods("GET")
+
+	api.Router.Handle("/filter-outputs/{filter_output_id}", assert.FilterOutputType(http.HandlerFunc(api.getFilterOutputHandler))).Methods("GET")
 
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}", api.addFilterBlueprintDimensionHandler).Methods("POST")
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}", api.patchFilterBlueprintDimensionHandler).Methods("PATCH")
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}", api.removeFilterBlueprintDimensionHandler).Methods("DELETE")
-	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}/options", api.getFilterBlueprintDimensionOptionsHandler).Methods("GET")
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}/options/{option}", api.getFilterBlueprintDimensionOptionHandler).Methods("GET")
-	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}/options/{option}", api.addFilterBlueprintDimensionOptionHandler).Methods("POST")
 	api.Router.HandleFunc("/filters/{filter_blueprint_id}/dimensions/{name}/options/{option}", api.removeFilterBlueprintDimensionOptionHandler).Methods("DELETE")
-	api.Router.Handle("/filter-outputs/{filter_output_id}", assert.FilterOutputFilterType(http.HandlerFunc(api.getFilterOutputHandler))).Methods("GET")
 
 	if cfg.EnablePrivateEndpoints {
-		api.Router.Handle("/filter-outputs/{filter_output_id}", assert.FilterOutputFilterType(http.HandlerFunc(api.updateFilterOutputHandler))).Methods("PUT")
+		api.Router.Handle("/filter-outputs/{filter_output_id}", assert.FilterOutputType(http.HandlerFunc(api.updateFilterOutputHandler))).Methods("PUT")
 		api.Router.HandleFunc("/filter-outputs/{filter_output_id}/events", api.addEventHandler).Methods("POST")
 	}
 

--- a/middleware/assert.go
+++ b/middleware/assert.go
@@ -41,7 +41,7 @@ func NewAssert(r responder, d datasetAPIClient, f filterFlexAPIClient, ds datast
 
 // Filter Flex Forwarder that checks for filter in the route, not in the body as below.
 // Used for PUT filter-output/{filter-output-id}
-func (a *Assert) FilterOutputFilterType(next http.Handler) http.Handler {
+func (a *Assert) FilterOutputType(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !a.enabled {
 			next.ServeHTTP(w, r)
@@ -144,8 +144,8 @@ func (a *Assert) FilterType(next http.Handler) http.Handler {
 		f, err := a.store.GetFilter(ctx, filterID, anyEtagSelector)
 		if err != nil {
 			a.respond.Error(ctx, w, statusCode(err), er{
-				err: errors.Wrap(err, "failed to get dataset"),
-				msg: fmt.Sprintf("failed to get dataset"),
+				err: errors.Wrap(err, "failed to get filter"),
+				msg: fmt.Sprintf("failed to get filter"),
 			})
 			return
 		}
@@ -154,7 +154,7 @@ func (a *Assert) FilterType(next http.Handler) http.Handler {
 			if err := a.doProxyRequest(w, r); err != nil {
 				a.respond.Error(ctx, w, statusCode(err), er{
 					err: errors.Wrap(err, "failed to do proxy request"),
-					msg: fmt.Sprintf("failed to get dataset"),
+					msg: fmt.Sprintf("failed to get filter"),
 				})
 			}
 			return

--- a/middleware/assert_test.go
+++ b/middleware/assert_test.go
@@ -156,7 +156,7 @@ func TestAssertFilterType(t *testing.T) {
 				})
 
 				next := http.HandlerFunc(testHandler)
-				f := assert.FilterOutputFilterType(next)
+				f := assert.FilterOutputType(next)
 				f.ServeHTTP(w, r)
 
 				Convey("The response should call the datastore with the same filter output ID", func() {
@@ -206,7 +206,7 @@ func TestAssertFilterType(t *testing.T) {
 				})
 
 				next := http.HandlerFunc(testHandler)
-				f := assert.FilterOutputFilterType(next)
+				f := assert.FilterOutputType(next)
 				f.ServeHTTP(w, r)
 
 				Convey("The response should call the datastore with the same filter output ID", func() {


### PR DESCRIPTION
### What

wrap `POST /filters/{id}/dimensions/{dimension}/options/{option}` and `GET /filters/{id}/dimensions/{dimension}/options` with assert filter type middleware and add tests

### How to review

Check changes make sense

### Who can review

Anyone